### PR TITLE
add: 주문 엔티티 및 관련 타입 추가

### DIFF
--- a/src/main/java/com/bestcat/delivery/order/entity/Order.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/Order.java
@@ -1,0 +1,57 @@
+package com.bestcat.delivery.order.entity;
+
+import com.bestcat.delivery.order.entity.type.OrderStatus;
+import com.bestcat.delivery.order.entity.type.OrderType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_orders")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Order {
+    @Id
+    @GeneratedValue
+    @Column(name ="order_id",updatable = false, nullable = false)
+    private UUID orderId;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+//    private User user;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "store_id", nullable = false)
+//    private Store store;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_type", nullable = false, length = 20)
+    private OrderType orderType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private OrderStatus status;
+
+    @Column(name = "address", nullable = false, length = 500)
+    private String address;
+
+    @Column(name = "request_notes")
+    private String requestNotes;
+
+    //BaseEntity
+
+}

--- a/src/main/java/com/bestcat/delivery/order/entity/type/OrderStatus.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/type/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.bestcat.delivery.order.entity.type;
+
+public enum OrderStatus {
+    RECEIVED,
+    CANCELLED,
+    COMPLETED
+}

--- a/src/main/java/com/bestcat/delivery/order/entity/type/OrderType.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/type/OrderType.java
@@ -1,0 +1,6 @@
+package com.bestcat.delivery.order.entity.type;
+
+public enum OrderType {
+    ONLINE,
+    IN_PERSON
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호

#8 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명합니다.

- `Order` 엔티티 추가
  - 주문의 고유 ID(`UUID`), 주문 타입(`OrderType`), 상태(`OrderStatus`), 주소, 요청 사항 등의 필드 포함
  - `OrderType`과 `OrderStatus`는 각각 ENUM 타입으로 정의

- 관련 타입(`OrderStatus`, `OrderType`) 추가
  - **OrderStatus**: `RECEIVED`, `CANCELLED`, `COMPLETED`
  - **OrderType**: `ONLINE`, `IN_PERSON`

### 스크린샷 (선택)

> 스크린샷이나 코드 스니펫 등을 추가해 설명할 수 있습니다.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성합니다.

-`OrderStatus`와 `OrderType` ENUM 값의 명칭이 적절한지 의견 주시면 감사하겠습니다.

--- 