### PR TITLE
[FEAT] #6, #11, #13 security 설정 추가, signin & signup 추가, BaseEntity createdBy, updatedBy 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,22 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // jwt
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // validation
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bestcat/delivery/ai/entity/AiLog.java
+++ b/src/main/java/com/bestcat/delivery/ai/entity/AiLog.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public class AiLog extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
     private String reqText;

--- a/src/main/java/com/bestcat/delivery/ai/entity/AiLog.java
+++ b/src/main/java/com/bestcat/delivery/ai/entity/AiLog.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public class AiLog extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     private String reqText;

--- a/src/main/java/com/bestcat/delivery/common/config/AuditorAwareImpl.java
+++ b/src/main/java/com/bestcat/delivery/common/config/AuditorAwareImpl.java
@@ -1,0 +1,25 @@
+package com.bestcat.delivery.common.config;
+
+import com.bestcat.delivery.common.util.UserDetailsImpl;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<UUID> {
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated() || !(authentication.getPrincipal() instanceof UserDetailsImpl)) {
+            return Optional.empty();
+        }
+
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+        return Optional.of(userDetails.getUser().getId());  // UUID 타입의 사용자 ID 반환
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/config/JpaConfig.java
+++ b/src/main/java/com/bestcat/delivery/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.bestcat.delivery.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")  // AuditorAware 구현체 지정
+public class JpaConfig {
+}

--- a/src/main/java/com/bestcat/delivery/common/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/bestcat/delivery/common/config/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package com.bestcat.delivery.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/bestcat/delivery/common/config/WebSecurityConfig.java
@@ -1,0 +1,78 @@
+package com.bestcat.delivery.common.config;
+
+
+import com.bestcat.delivery.common.util.JwtAuthenticationFilter;
+import com.bestcat.delivery.common.util.JwtAuthorizationFilter;
+import com.bestcat.delivery.common.util.JwtUtil;
+import com.bestcat.delivery.common.util.UserDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true, prePostEnabled = true)
+@EnableWebSecurity // Spring Security 지원을 가능하게 함
+public class WebSecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+
+    // 인증 필터 등록
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+
+    // 인가 필터 등록
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
+                authorizeHttpRequests
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+                        .requestMatchers("/api/users/signin", "/api/users/signup").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
+                        .anyRequest().authenticated() // 그 외 모든 요청 인증처리
+        );
+
+        http.formLogin(AbstractHttpConfigurer::disable);
+
+        // 필터 관리 http.addFilterBefore(선행될 필터, 이후 필터)
+        http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/entity/BaseEntity.java
+++ b/src/main/java/com/bestcat/delivery/common/entity/BaseEntity.java
@@ -8,8 +8,7 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.sql.Timestamp;
-import java.util.UUID;
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -17,18 +16,24 @@ import java.util.UUID;
 public class BaseEntity {
     @CreatedDate
     @Column(updatable = false)
-    private Timestamp createdAt;
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
 
     @CreatedBy
-    private UUID createdBy;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User createdBy;
 
     @LastModifiedDate
-    private Timestamp updateAt;
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime updateAt;
 
     @LastModifiedBy
-    private UUID updateBy;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User updateBy;
 
-    private Timestamp deleteAt;
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime deleteAt;
 
-    private UUID deleteBy;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User deleteBy;
 }

--- a/src/main/java/com/bestcat/delivery/common/entity/BaseEntity.java
+++ b/src/main/java/com/bestcat/delivery/common/entity/BaseEntity.java
@@ -8,7 +8,8 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
+import java.util.UUID;
 
 @Getter
 @MappedSuperclass
@@ -16,24 +17,18 @@ import java.time.LocalDateTime;
 public class BaseEntity {
     @CreatedDate
     @Column(updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime createdAt;
+    private Timestamp createdAt;
 
     @CreatedBy
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User createdBy;
+    private UUID createdBy;
 
     @LastModifiedDate
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime updateAt;
+    private Timestamp updateAt;
 
     @LastModifiedBy
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User updateBy;
+    private UUID updateBy;
 
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime deleteAt;
+    private Timestamp deleteAt;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User deleteBy;
+    private UUID deleteBy;
 }

--- a/src/main/java/com/bestcat/delivery/common/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bestcat/delivery/common/util/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.bestcat.delivery.common.util;
+
+import com.bestcat.delivery.user.dto.SigninRequestDto;
+import com.bestcat.delivery.user.entity.RoleType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+        setFilterProcessesUrl("/api/users/signin");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        log.info("로그인 시도");
+        try {
+            SigninRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(), SigninRequestDto.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            requestDto.username(),
+                            requestDto.password(),
+                            null
+                    )
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        log.info("로그인 성공 및 JWT 생성");
+        UUID id = ((UserDetailsImpl) authResult.getPrincipal()).getUserId();
+        String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+        RoleType role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+
+        String token = jwtUtil.createToken(id, username, role);
+        jwtUtil.addJwtToCookie(token, response);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        log.info("로그인 실패");
+        response.setStatus(401);
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/util/JwtAuthorizationFilter.java
+++ b/src/main/java/com/bestcat/delivery/common/util/JwtAuthorizationFilter.java
@@ -1,0 +1,71 @@
+package com.bestcat.delivery.common.util;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = jwtUtil.getTokenFromRequest(req);
+
+        if (StringUtils.hasText(tokenValue)) {
+            // JWT 토큰 substring
+            tokenValue = jwtUtil.substringToken(tokenValue);
+            log.info(tokenValue);
+
+            if (!jwtUtil.validateToken(tokenValue)) {
+                log.error("Token Error");
+                return;
+            }
+
+            Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+
+            try {
+                setAuthentication((String)info.get("username"));
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    // 인증 처리
+    public void setAuthentication(String username) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String username) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/util/JwtUtil.java
+++ b/src/main/java/com/bestcat/delivery/common/util/JwtUtil.java
@@ -1,0 +1,162 @@
+package com.bestcat.delivery.common.util;
+
+
+import com.bestcat.delivery.user.entity.RoleType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+// @Slf4j
+@Component
+public class JwtUtil {
+    // Header
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    // 사용자 권한 값의 KEY
+    public static final String AUTHORIZATION_KEY = "auth";
+    // Token 식별자
+    public static final String Bearer_PREFIX = "Bearer ";
+    // 토큰 만료 시간
+    private final long TOKEN_TIME = 60 * 60 * 1000;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private Key key;
+
+    // 알고리즘 선택
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    // 로그 설정
+    private static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
+
+    // 여러번 요정되는 것을 방지
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // JWT 생성
+    public String createToken(UUID userId, String username, RoleType role) {
+        Date date = new Date();
+
+        return Bearer_PREFIX +
+                Jwts.builder()
+                        .setSubject(userId.toString()
+                        )   // 사용자 식별 ID
+                        .claim(AUTHORIZATION_KEY, role) // 사용자 권한
+                        .claim("username", username)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))   // 만료 시간
+                        .setIssuedAt(date)  // 발급일
+                        .signWith(key, signatureAlgorithm)  // 암호화 알고리즘
+                        .compact();
+    }
+
+    // JWT Cookie 에 저장
+    public void addJwtToCookie(String token, HttpServletResponse res) {
+        try {
+            token = URLEncoder.encode(token, "utf-8").replace("\\+", "%20");
+
+            Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token);    // name-value
+            cookie.setPath("/");
+
+            // Response 객체에 Cookie 추가
+            res.addCookie(cookie);
+
+        } catch (UnsupportedEncodingException e) {
+            logger.error(e.getMessage());
+        }
+    }
+
+    // JWT substring
+    public String substringToken(String token) {
+        if(StringUtils.hasText(token) && token.startsWith(Bearer_PREFIX)) {
+            return token.substring(Bearer_PREFIX.length());
+        }
+        logger.error("Not Found Token");
+
+        throw new NullPointerException("Not Found Token");
+    }
+
+    // JWT 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SignatureException | SecurityException | MalformedJwtException e) {
+            logger.error("Invalid JWT signature, 유효하지 않은 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.error("Expired JWT, 만료된 JWT 입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.error("Unsupported JWT, 지원하지 않는 JWT 입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.error("JWT claims is empty, 잘못된 JWT 입니다.");
+        }
+
+        return false;
+    }
+
+    // token 에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("username", String.class);
+    }
+
+    public List<String> getRoles(String token) {
+
+        List<?> roles = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("roles", List.class);
+
+        if (roles != null) {
+            return roles.stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    // HttpServletRequest 에서 Cookie Value : JWT 가져오기
+    public String getTokenFromRequest(HttpServletRequest req) {
+        Cookie[] cookies = req.getCookies();
+        if(cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(AUTHORIZATION_HEADER)) {
+                    try {
+                        return URLDecoder.decode(cookie.getValue(), "UTF-8"); // Encode 되어 넘어간 Value 다시 Decode
+                    } catch (UnsupportedEncodingException e) {
+                        return null;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/util/UserDetailsImpl.java
+++ b/src/main/java/com/bestcat/delivery/common/util/UserDetailsImpl.java
@@ -1,0 +1,70 @@
+package com.bestcat.delivery.common.util;
+
+import com.bestcat.delivery.user.entity.RoleType;
+import com.bestcat.delivery.user.entity.User;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public UUID getUserId() {
+        return user.getId();
+    }
+
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        RoleType role = user.getRole();
+        String authority = role.getAuthority();
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/util/UserDetailsServiceImpl.java
+++ b/src/main/java/com/bestcat/delivery/common/util/UserDetailsServiceImpl.java
@@ -1,0 +1,24 @@
+package com.bestcat.delivery.common.util;
+
+import com.bestcat.delivery.user.entity.User;
+import com.bestcat.delivery.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/bestcat/delivery/order/entity/Order.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/Order.java
@@ -2,12 +2,14 @@ package com.bestcat.delivery.order.entity;
 
 import com.bestcat.delivery.order.entity.type.OrderStatus;
 import com.bestcat.delivery.order.entity.type.OrderType;
+import com.bestcat.delivery.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -26,13 +28,13 @@ import lombok.NoArgsConstructor;
 @Builder
 public class Order {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name ="order_id",updatable = false, nullable = false)
     private UUID orderId;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "user_id", nullable = false)
-//    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
 //    @ManyToOne(fetch = FetchType.LAZY)
 //    @JoinColumn(name = "store_id", nullable = false)

--- a/src/main/java/com/bestcat/delivery/review/entity/Review.java
+++ b/src/main/java/com/bestcat/delivery/review/entity/Review.java
@@ -1,6 +1,7 @@
 package com.bestcat.delivery.review.entity;
 
 import com.bestcat.delivery.common.entity.BaseEntity;
+import com.bestcat.delivery.order.entity.Order;
 import com.bestcat.delivery.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -23,16 +24,16 @@ public class Review extends BaseEntity {
     private UUID id;
 
     @ManyToOne
-    @Column(name = "user_id")
+    @JoinColumn(name = "user_id")
     private User user;
 
-//    @ManyToOne
-//    @Column(name = "order_id")
-//    private Order order;
+    @ManyToOne
+    @JoinColumn(name = "order_id")
+    private Order order;
 
     private String content;
     private Integer rating;
 
-    private Timestamp delete_at;
+    // private Timestamp delete_at;
 
 }

--- a/src/main/java/com/bestcat/delivery/review/entity/ReviewPhoto.java
+++ b/src/main/java/com/bestcat/delivery/review/entity/ReviewPhoto.java
@@ -21,7 +21,7 @@ public class ReviewPhoto extends BaseEntity {
     private UUID id;
 
     @ManyToOne
-    @Column(name = "review_id")
+    @JoinColumn(name = "review_id")
     private Review review;
 
     private String url;

--- a/src/main/java/com/bestcat/delivery/user/dto/SigninRequestDto.java
+++ b/src/main/java/com/bestcat/delivery/user/dto/SigninRequestDto.java
@@ -1,0 +1,12 @@
+package com.bestcat.delivery.user.dto;
+
+import com.bestcat.delivery.user.entity.User;
+
+public record SigninRequestDto(
+        String username,
+        String password
+) {
+    public User toEntity() {
+        return User.builder().username(username).password(password).build();
+    }
+}

--- a/src/main/java/com/bestcat/delivery/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/bestcat/delivery/user/dto/SignupRequestDto.java
@@ -1,0 +1,41 @@
+package com.bestcat.delivery.user.dto;
+
+import com.bestcat.delivery.user.entity.RoleType;
+import com.bestcat.delivery.user.entity.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequestDto (
+        @NotBlank(message = "유저 아이디을 입력해주세요.")
+        @Size(min =8, max = 15, message = "8자 이상 15자 이하로 입력할 수 있습니다.")
+        String username,
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 20, message = "최소 8자 이상, 15자 이하의 글자만 입력할 수 있습니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*]*$", message = "알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자(!@#$%^&*) 만 입력 가능합니다.")
+        String password,
+
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(min = 2, max = 10, message = "최소 2자 이상, 10자 이하의 글자만 입력할 수 없습니다.")
+        String nickname,
+
+        @NotBlank(message = "권한을 선택해주세요.")
+        String role
+) {
+    public User toEntity() {
+        return User.builder()
+                .username(username)
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .role(RoleType.valueOf(role))
+                .build();
+    }
+}
+

--- a/src/main/java/com/bestcat/delivery/user/repository/UserRepository.java
+++ b/src/main/java/com/bestcat/delivery/user/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.bestcat.delivery.user.repository;
+
+import com.bestcat.delivery.user.entity.User;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    boolean existsByEmail(String email);
+
+    boolean existsByUsername(String username);
+
+    boolean existsByNickname(String nickname);
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/bestcat/delivery/user/service/UserService.java
+++ b/src/main/java/com/bestcat/delivery/user/service/UserService.java
@@ -1,0 +1,50 @@
+package com.bestcat.delivery.user.service;
+
+import com.bestcat.delivery.user.dto.SignupRequestDto;
+import com.bestcat.delivery.user.entity.User;
+import com.bestcat.delivery.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signup(SignupRequestDto signupRequestDto) {
+        User user = signupRequestDto.toEntity();
+
+        if(checkUsername(user.getUsername())) {
+            throw new IllegalArgumentException("중복된 아이디입니다. 다른 아이디를 사용해주세요.");
+        }
+
+        if(checkEmail(user.getEmail())) {
+            throw new IllegalArgumentException("중복된 이메일입니다. 다른 이메일을 사용해주세요.");
+        }
+
+        if(checkNickname(user.getNickname())) {
+            throw new IllegalArgumentException("중복된 닉네임입니다. 다른 닉네임을 사용해주세요.");
+        }
+
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+
+        userRepository.save(user);
+    }
+
+
+
+    public boolean checkEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    public boolean checkUsername(String username) {
+        return userRepository.existsByUsername(username);
+    }
+
+    public boolean checkNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+}

--- a/src/main/java/com/bestcat/delivery/user/web/UserController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/UserController.java
@@ -1,0 +1,24 @@
+package com.bestcat.delivery.user.web;
+
+import com.bestcat.delivery.user.dto.SignupRequestDto;
+import com.bestcat.delivery.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public void signup(@Valid @RequestBody SignupRequestDto requestDto) {
+        userService.signup(requestDto);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+jwt:
+  secret:
+    key: 7Iqk7YyM66W07YOA7L2U65Sp7YG065+9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg==


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 [FEAT] 회원 가입 및 로그인 기능 추가
> #11 [FEAT] Security 설정 및 Filter 설정
> #13 [Chore] BaseEntity의 createdBy, updatedBy 관련 설정 추가

## 📝작업 내용

### 1. 회원 가입 및 로그인 기능을 추가하였습니다.
   - 로그인 시 Authorization 키값으로 쿠기에 저장합니다.
   - Postman으로 작업 시 해당 쿠기값이 만료되었다고 나오면 밑의 사진처럼 쿠키에 들어가서 Authorization 을 삭제해주시면 다시 동작하게 됩니다.
    ![image](https://github.com/user-attachments/assets/f0fdf323-ff59-4694-95d9-4657106d18c1)


### 2. Security 관련 설정 기능을 추가하였습니다.
- 비밀번호 알고리즘은 BCryptPasswordEncoder 를 사용하였습니다.
- 현재 /api/users/signin 과 /api/users/signup 의 url은 permitAll 로 설정해두었습니다
- 다른 url의 경우 권한이 필요없으시면 `WebSecurityConfig`에 가서 url을 추가해주시면 됩니다.
- 로그인 한 유저의 정보가 필요한 경우
   - `@AuthenticationPrincipal UserDetailsImpl userDetails` 를 매개변수에 추가해주세요.
       ``` java
         // 예시
         public ResponseEntity<UserInfoDto> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
              return ResponseEntity.ok(new UserInfoDto(userDetails));
        }
       ```
   - userDetails.getUser() 를 하면 로그인 된 유저 객체를 가져올 수 있습니다.    
   - 해당 메서드에 권한을 주는 방법 3가지
       1. Controller 메서드에 `@Secured({"ROLE_MASTER", "ROLE_MANAGER", "ROLE_OWNER", "ROLE_CUSTOMER"})` 추가
       2. Controller 메서드에 `@PreAuthorize("hasAnyRole('MASTER', 'MANAGER')")` 혹은 `@PreAuthorize("hasAnyRole('ROLE_MASTER', 'ROLE_MANAGER')")` 추가
       ``` java
         // 예시 ( 두가지 중 하나 선택)
         // @Secured({"ROLE_MASTER", "ROLE_MANAGER", "ROLE_OWNER", "ROLE_CUSTOMER"})
         @PreAuthorize("hasAnyRole('MASTER', 'MANAGER')")
         public ResponseEntity<UserInfoDto> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
              return ResponseEntity.ok(new UserInfoDto(userDetails));
        }
       ```
       3. WebSecurityConfig 에 `.requestMatchers("/api/auth/check-nickname").hasRole("MASTER")` 추가

### 3.  BaseEntity의 @CreatedBy 와 @UpdatedBy 의 값이 User 테이블의 UUID 인 id 값이 적용되도록 설정을 추가하였습니다.
- AuditorAware<UUID> 를 상속 받아 @Override getCurrentAuditor() 메서드를 작성하였습니다.
- 현재 로그인 된 사용자의 쿠키에서 사용자 정보를 가져와 User 객체를 가져와 update 되도록 적용했습니다.


### 4. 연관된 테이블의 어노테이션을 @Column에서 @JoinColumn으로 변경하였고, id에 GenerationType.UUID 를 추가해두었습니다.
- 현재까지 merge 된 테이블들은 주석 해제하여 연결되도록 하였습니다.


## 💬 
- 한번에 많은 파일을 pr에 올려서 죄송합니다. 로그인 관련된 security 설정들을 추가하다보니 규모가 커졌습니다. 다음번 pr들은 더 잘게 쪼개서 올리도록 하겠습니다.
- 회원 가입 시 createBy와 updatedBy는 적용되지 않더라고요. (로그인 한 회원이 없으니 당연하게도 되지 않음...), 따로 id 값을 set으로 randomUUID() 로 생성하여 createBy와 updatedBy 모두 같은 아이디로 넣어주었는데 db에는 id 값이 다른 값으로 들어가더라고요. 제 생각엔 db에서 id값을 넣어주는 동작을 해서 그런 것 같습니다. 회원 가입 시 createBy와 updatedBy가 작성되지 않아도 상관 없을까요?
- 궁금하신 점 편히 물어봐주세요!

