### PR TITLE
[Chore] add global exception

### DIFF
--- a/src/main/java/com/bestcat/delivery/common/dto/ErrorResponse.java
+++ b/src/main/java/com/bestcat/delivery/common/dto/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.bestcat.delivery.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.validation.FieldError;
+
+@Builder
+public record ErrorResponse(
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ValidationError> errors
+) {
+
+    @Builder
+    public record ValidationError(
+            String field,
+            String message
+    ) {
+
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/dto/SuccessResponse.java
+++ b/src/main/java/com/bestcat/delivery/common/dto/SuccessResponse.java
@@ -1,0 +1,36 @@
+package com.bestcat.delivery.common.dto;
+
+import com.bestcat.delivery.common.type.ResponseMessage;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+public record SuccessResponse<T>(
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL) T data
+) {
+
+    public static <T> SuccessResponse<T> of(ResponseMessage message, T data) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message(message.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(ResponseMessage message) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message(message.getMessage())
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(T data) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message("")
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/bestcat/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bestcat/delivery/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,119 @@
+package com.bestcat.delivery.common.exception;
+
+
+import static com.bestcat.delivery.common.type.ErrorCode.BAD_REQUEST;
+import static com.bestcat.delivery.common.type.ErrorCode.INTERNAL_SERVER_ERROR;
+
+import com.bestcat.delivery.common.dto.ErrorResponse;
+import com.bestcat.delivery.common.dto.ErrorResponse.ValidationError;
+import com.bestcat.delivery.common.type.ErrorCode;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * RestApiException(커스텀 에러) 처리
+     *
+     * @param e RestApiException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<Object> handleCustomException(RestApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("RestApiException occurred : ErrorCode = {} message = {}",
+                errorCode.name(), errorCode.getDescription());
+        return handleExceptionInternal(errorCode);
+    }
+
+    /**
+     * MethodArgumentNotValidException 처리 (Validation 실패 등)
+     *
+     * @param e MethodArgumentNotValidException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException occurred ", e);
+        return handleExceptionInternal(e, BAD_REQUEST);
+    }
+
+    /**
+     * IllegalArgumentException 처리 (적절하지 않은 파라미터)
+     *
+     * @param e IllegalArgumentException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
+        log.error("IllegalArgumentException occurred", e);
+        return handleExceptionInternal(BAD_REQUEST);
+    }
+
+    /**
+     * DataIntegrityViolationException 처리 (DB 제약 조건 위반)
+     *
+     * @param e DataIntegrityViolationException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        log.error("DataIntegrityViolationException occurred", e);
+        return handleExceptionInternal(BAD_REQUEST);
+    }
+
+    /**
+     * Exception 처리
+     *
+     * @param e Exception
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleException(Exception e) {
+        log.error("Unexpected Exception occurred", e);
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(INTERNAL_SERVER_ERROR.getDescription());
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponseBody(errorCode));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponseBody((MethodArgumentNotValidException) e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponseBody(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .build();
+    }
+
+    private ErrorResponse makeErrorResponseBody(BindException e, ErrorCode errorCode) {
+        List<ValidationError> validationErrorList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .errors(validationErrorList)
+                .build();
+    }
+
+}

--- a/src/main/java/com/bestcat/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bestcat/delivery/common/exception/GlobalExceptionHandler.java
@@ -7,12 +7,16 @@ import static com.bestcat.delivery.common.type.ErrorCode.INTERNAL_SERVER_ERROR;
 import com.bestcat.delivery.common.dto.ErrorResponse;
 import com.bestcat.delivery.common.dto.ErrorResponse.ValidationError;
 import com.bestcat.delivery.common.type.ErrorCode;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -43,8 +47,14 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
-        log.error("MethodArgumentNotValidException occurred ", e);
-        return handleExceptionInternal(e, BAD_REQUEST);
+        Map<String, String> errors = new HashMap<>();
+
+        // 모든 유효성 검증 오류를 가져와서 메시지를 구성
+        for (FieldError error : e.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
     /**

--- a/src/main/java/com/bestcat/delivery/common/exception/RestApiException.java
+++ b/src/main/java/com/bestcat/delivery/common/exception/RestApiException.java
@@ -1,0 +1,12 @@
+package com.bestcat.delivery.common.exception;
+
+import com.bestcat.delivery.common.type.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
+++ b/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
@@ -1,0 +1,39 @@
+package com.bestcat.delivery.common.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    NOT_AUTHENTICATED_USER(HttpStatus.UNAUTHORIZED, "인증된 사용자가 아닙니다."),
+    UNEXPECTED_PRINCIPAL_TYPE(HttpStatus.BAD_REQUEST, "예상치 못한 Principal 타입입니다."),
+
+
+    // 유저
+    USER_ID_MISMATCH(HttpStatus.BAD_REQUEST, "로그인한 유저와 요청된 user-id가 일치하지 않습니다."),
+    ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+
+
+    // area
+    SERVICE_AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 지역입니다."),
+
+
+    // delivery
+    DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 배달 주소를 찾을 수 없습니다."),
+
+
+    // 다른 도메인 추가...
+
+    ;
+    private final HttpStatus httpStatus;
+    private final String description;
+}
+

--- a/src/main/java/com/bestcat/delivery/common/type/ResponseMessage.java
+++ b/src/main/java/com/bestcat/delivery/common/type/ResponseMessage.java
@@ -1,0 +1,23 @@
+package com.bestcat.delivery.common.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+    // 유저 관련
+    SIGNUP_SUCCESS("회원가입 성공"),
+    SIGNIN_SUCCESS("로그인 성공"),
+    GET_USER_INFO_SUCCESS("사용자 정보 조회 성공"),
+
+
+    // 다른 도메인 추가...
+
+
+
+
+
+    ;
+    private final String message;
+}

--- a/src/main/java/com/bestcat/delivery/common/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bestcat/delivery/common/util/JwtAuthenticationFilter.java
@@ -1,5 +1,9 @@
 package com.bestcat.delivery.common.util;
 
+import static com.bestcat.delivery.common.type.ResponseMessage.SIGNIN_SUCCESS;
+
+import com.bestcat.delivery.common.dto.SuccessResponse;
+import com.bestcat.delivery.common.type.ResponseMessage;
 import com.bestcat.delivery.user.dto.SigninRequestDto;
 import com.bestcat.delivery.user.entity.RoleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,6 +56,14 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
         String token = jwtUtil.createToken(id, username, role);
         jwtUtil.addJwtToCookie(token, response);
+        // 로그인 성공 메시지 작성
+        SuccessResponse<ResponseMessage> successResponse = SuccessResponse.of(SIGNIN_SUCCESS);
+
+        // JSON 응답을 반환
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(successResponse));
+        response.getWriter().flush();
     }
 
     @Override

--- a/src/main/java/com/bestcat/delivery/menu/entity/Menu.java
+++ b/src/main/java/com/bestcat/delivery/menu/entity/Menu.java
@@ -22,11 +22,11 @@ public class Menu extends BaseEntity {
     private UUID id;
 
     @ManyToOne
-    @Column(name = "store_id")
+    @JoinColumn(name = "store_id")
     private Store store;
 
     @ManyToOne
-    @Column(name = "category_id")
+    @JoinColumn(name = "category_id")
     private Category category;
 
 

--- a/src/main/java/com/bestcat/delivery/user/dto/UserInfoDto.java
+++ b/src/main/java/com/bestcat/delivery/user/dto/UserInfoDto.java
@@ -1,0 +1,15 @@
+package com.bestcat.delivery.user.dto;
+
+import com.bestcat.delivery.common.util.UserDetailsImpl;
+
+public record UserInfoDto (
+        String username,
+        String email,
+        String nickname
+){
+    public UserInfoDto(UserDetailsImpl userDetails) {
+        this(userDetails.getUser().getUsername(),
+                userDetails.getUser().getEmail(),
+                userDetails.getUser().getNickname());
+    }
+}

--- a/src/main/java/com/bestcat/delivery/user/web/UserController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/UserController.java
@@ -1,9 +1,21 @@
 package com.bestcat.delivery.user.web;
 
+import static com.bestcat.delivery.common.type.ResponseMessage.GET_USER_INFO_SUCCESS;
+import static com.bestcat.delivery.common.type.ResponseMessage.SIGNIN_SUCCESS;
+import static com.bestcat.delivery.common.type.ResponseMessage.SIGNUP_SUCCESS;
+
+import com.bestcat.delivery.common.dto.SuccessResponse;
+import com.bestcat.delivery.common.type.ResponseMessage;
+import com.bestcat.delivery.common.util.UserDetailsImpl;
 import com.bestcat.delivery.user.dto.SignupRequestDto;
+import com.bestcat.delivery.user.dto.UserInfoDto;
 import com.bestcat.delivery.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,8 +29,16 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public void signup(@Valid @RequestBody SignupRequestDto requestDto) {
+    public ResponseEntity<SuccessResponse<ResponseMessage>> signup(@Valid @RequestBody SignupRequestDto requestDto) {
         userService.signup(requestDto);
+
+        return ResponseEntity.ok(SuccessResponse.of(SIGNUP_SUCCESS));
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<UserInfoDto>> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(GET_USER_INFO_SUCCESS, new UserInfoDto(userDetails)));
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #12

## 📝작업 내용

> global exception 관련된 파일들을 추가하였습니다.
- 추가된 파일
   ![image](https://github.com/user-attachments/assets/e00f69ae-ad2e-49d7-a7e2-3b413b072945)
- ResponseMessage -> SuccessResponse 내에 추가할 메세지를 넣어주시면 됩니다.
  ![image](https://github.com/user-attachments/assets/69339f64-58ab-4396-a28f-4f6b33f21ce9)
- 예시) 반환 타입을 ResponseEntity<SuccessResponse<body에 반환할 객체타입>> 을 주시면 됩니다.
   타입이 없을 시 ResponseMessage만 담으셔도 됩니다.
   - SuccessResponse.of(ResponseMessage) 혹은 SuccessResponse.of(ResponseMessage, data\<T\>) 형태로 담아주면 됩니다.
   ![image](https://github.com/user-attachments/assets/cf7db0dc-fdf8-4c78-b0a6-40c0cceb1458)
- service 단에서 exception을 던질 때 new RestApiException(ErrorCode) 로 넣으면 됩니다.
- 예시) illegalException 과 같은 타입도 에러 코드를 전송하도록 추가하고 싶으시면 GlobalExcepionHandler에 추가하시면 됩니다.
   ![image](https://github.com/user-attachments/assets/58e93245-36e8-4943-a2a6-06b1174478bb)
   ![image](https://github.com/user-attachments/assets/d5907df0-ee21-46b4-bf9a-d7878e1ed59a)



### 스크린샷 (선택)
- Postman 응답 예시
![image](https://github.com/user-attachments/assets/5089c6bc-4281-4ca5-9d37-02a2a30aef90)
![image](https://github.com/user-attachments/assets/3b739bcb-1505-40b5-b12b-44e0e1f6accb)



## 💬리뷰 요구사항
- 저는 이런 식으로 작업을 했었는데 더 좋은 방법의 코드가 있으면 공유 부탁드려요!
