### PR TITLE
[FEAT] 유저 관련 기능 추가 및 리팩터링

### DIFF
--- a/src/main/java/com/bestcat/delivery/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/bestcat/delivery/common/config/WebSecurityConfig.java
@@ -39,6 +39,7 @@ public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final CustomLogoutHandler customLogoutHandler;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -76,7 +77,7 @@ public class WebSecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/api/users/signin", "/api/users/signup", "/api/auth/*").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
-        ).logout(jwtUtil::configureLogout);
+        ).logout(customLogoutHandler::configureLogout);
 
         http.formLogin(AbstractHttpConfigurer::disable);
 

--- a/src/main/java/com/bestcat/delivery/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/bestcat/delivery/common/config/WebSecurityConfig.java
@@ -1,11 +1,20 @@
 package com.bestcat.delivery.common.config;
 
 
+import static com.bestcat.delivery.common.type.ResponseMessage.LOGOUT_SUCCESS;
+import static com.bestcat.delivery.common.type.ResponseMessage.SIGN_IN_SUCCESS;
+
+import com.bestcat.delivery.common.dto.SuccessResponse;
+import com.bestcat.delivery.common.type.ResponseMessage;
+import com.bestcat.delivery.common.util.CustomLogoutHandler;
 import com.bestcat.delivery.common.util.JwtAuthenticationFilter;
 import com.bestcat.delivery.common.util.JwtAuthorizationFilter;
 import com.bestcat.delivery.common.util.JwtUtil;
 import com.bestcat.delivery.common.util.UserDetailsServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,9 +24,11 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
 
 @Configuration
 @RequiredArgsConstructor
@@ -63,9 +74,9 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-                        .requestMatchers("/api/users/signin", "/api/users/signup").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
+                        .requestMatchers("/api/users/signin", "/api/users/signup", "/api/auth/*").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
-        );
+        ).logout(jwtUtil::configureLogout);
 
         http.formLogin(AbstractHttpConfigurer::disable);
 

--- a/src/main/java/com/bestcat/delivery/common/dto/SuccessResponse.java
+++ b/src/main/java/com/bestcat/delivery/common/dto/SuccessResponse.java
@@ -33,4 +33,11 @@ public record SuccessResponse<T>(
                 .data(data)
                 .build();
     }
+
+    public static <T> SuccessResponse<T> of(String code, ResponseMessage message) {
+        return SuccessResponse.<T>builder()
+                .code(code)
+                .message(message.getMessage())
+                .build();
+    }
 }

--- a/src/main/java/com/bestcat/delivery/common/entity/BaseEntity.java
+++ b/src/main/java/com/bestcat/delivery/common/entity/BaseEntity.java
@@ -1,12 +1,17 @@
 package com.bestcat.delivery.common.entity;
 
+import static com.bestcat.delivery.common.type.ErrorCode.NOT_AUTHENTICATED_USER;
+
+import com.bestcat.delivery.common.exception.RestApiException;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import com.bestcat.delivery.common.config.AuditorAwareImpl;
 
 import java.sql.Timestamp;
 import java.util.UUID;
@@ -19,17 +24,31 @@ public class BaseEntity {
     @Column(updatable = false)
     private Timestamp createdAt;
 
+    @Setter
     @CreatedBy
     private UUID createdBy;
 
     @LastModifiedDate
     private Timestamp updateAt;
 
+    @Setter
     @LastModifiedBy
-    private UUID updateBy;
+    private UUID updatedBy;
 
-    private Timestamp deleteAt;
+    private Timestamp deletedAt;
 
-    private UUID deleteBy;
+    private UUID deletedBy;
 
+    public void updateDeleted() {
+        // 현재 시간으로 삭제 시간 설정
+        this.deletedAt = new Timestamp(System.currentTimeMillis());
+
+        // 삭제한 사용자를 설정
+        this.deletedBy = getCurrentAuditorId();
+    }
+
+    private UUID getCurrentAuditorId() {
+        return new AuditorAwareImpl().getCurrentAuditor().orElseThrow(() ->
+                new RestApiException(NOT_AUTHENTICATED_USER));
+    }
 }

--- a/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
+++ b/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    SIGN_IN_FAILED(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다"),
+    NEW_PASSWORD_SAME_AS_CURRENT(HttpStatus.BAD_REQUEST, "현재 사용중인 비밀번호와 일치합니다."),
 
 
     // area

--- a/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
+++ b/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     SIGN_IN_FAILED(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다"),
     NEW_PASSWORD_SAME_AS_CURRENT(HttpStatus.BAD_REQUEST, "현재 사용중인 비밀번호와 일치합니다."),
+    CANNOT_FOUND_LOGIN_USER(HttpStatus.UNAUTHORIZED, "현재 로그인 된 유저가 없습니다."),
 
 
     // area

--- a/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
+++ b/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
 
 
     // area
-    SERVICE_AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 지역입니다."),
+    AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 지역입니다."),
 
 
     // delivery

--- a/src/main/java/com/bestcat/delivery/common/type/ResponseMessage.java
+++ b/src/main/java/com/bestcat/delivery/common/type/ResponseMessage.java
@@ -7,9 +7,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
     // 유저 관련
-    SIGNUP_SUCCESS("회원가입 성공"),
-    SIGNIN_SUCCESS("로그인 성공"),
+    SIGN_UP_SUCCESS("회원가입 성공"),
+    SIGN_IN_SUCCESS("로그인 성공"),
+    LOGOUT_SUCCESS("로그아웃 성공"),
     GET_USER_INFO_SUCCESS("사용자 정보 조회 성공"),
+    DELETE_USER_SUCCESS("유저 삭제 성공"),
+    NICKNAME_CANT_USE("닉네임 사용 불가"),
+    NICKNAME_CAN_USE("닉네임 사용 가능"),
+    USERNAME_CAN_USE("사용자 아이디 사용 가능"),
+    USERNAME_CANT_USE("사용자 아이디 사용 불가"),
+    PASSWORD_UPDATE_SUCCESS("비밀번호 변경 성공"),
+    NICKNAME_UPDATE_SUCCESS("닉네임 변경 성공"),
 
 
     // 다른 도메인 추가...

--- a/src/main/java/com/bestcat/delivery/common/util/CustomLogoutHandler.java
+++ b/src/main/java/com/bestcat/delivery/common/util/CustomLogoutHandler.java
@@ -1,0 +1,31 @@
+package com.bestcat.delivery.common.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomLogoutHandler implements LogoutHandler {
+    private static final Logger logger = LoggerFactory.getLogger("로그아웃 관련 로그");
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        // 쿠키 이름에 따라 삭제할 쿠키 설정
+        logger.info("로그아웃 시도");
+
+        Cookie cookie = new Cookie("Authorization", null);
+        cookie.setMaxAge(0);  // 쿠키의 만료시간을 0으로 설정하여 즉시 삭제
+        cookie.setPath("/");  // 쿠키 경로를 설정 (기본 경로로 설정)
+        response.addCookie(cookie);
+        logger.info("로그아웃 성공");
+    }
+
+}

--- a/src/main/java/com/bestcat/delivery/common/util/CustomLogoutHandler.java
+++ b/src/main/java/com/bestcat/delivery/common/util/CustomLogoutHandler.java
@@ -1,31 +1,95 @@
 package com.bestcat.delivery.common.util;
 
+import static com.bestcat.delivery.common.type.ErrorCode.CANNOT_FOUND_LOGIN_USER;
+import static com.bestcat.delivery.common.type.ResponseMessage.LOGOUT_SUCCESS;
+
+import com.bestcat.delivery.common.dto.ErrorResponse;
+import com.bestcat.delivery.common.dto.SuccessResponse;
+import com.bestcat.delivery.common.exception.RestApiException;
+import com.bestcat.delivery.common.type.ResponseMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
+@RequiredArgsConstructor
 public class CustomLogoutHandler implements LogoutHandler {
     private static final Logger logger = LoggerFactory.getLogger("로그아웃 관련 로그");
+    private final JwtUtil jwtUtil;
 
     @Override
-    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-        // 쿠키 이름에 따라 삭제할 쿠키 설정
-        logger.info("로그아웃 시도");
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws AuthorizationDeniedException{
+        String tokenValue = jwtUtil.getTokenFromRequest(request);
 
-        Cookie cookie = new Cookie("Authorization", null);
-        cookie.setMaxAge(0);  // 쿠키의 만료시간을 0으로 설정하여 즉시 삭제
-        cookie.setPath("/");  // 쿠키 경로를 설정 (기본 경로로 설정)
-        response.addCookie(cookie);
-        logger.info("로그아웃 성공");
+        if (StringUtils.hasText(tokenValue)) {
+            // JWT 토큰 substring
+            tokenValue = jwtUtil.substringToken(tokenValue);
+
+            if (!jwtUtil.validateToken(tokenValue)) {
+                logger.error("Token Error");
+                return;
+            }
+
+            Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+
+            // 쿠키 이름에 따라 삭제할 쿠키 설정
+            logger.info("로그아웃 시도 : {}", info.get("username"));
+
+            Cookie cookie = new Cookie("Authorization", null);
+            cookie.setMaxAge(0);  // 쿠키의 만료시간을 0으로 설정하여 즉시 삭제
+            cookie.setPath("/");  // 쿠키 경로를 설정 (기본 경로로 설정)
+            response.addCookie(cookie);
+            logger.info("로그아웃 성공");
+        } else {
+            logger.error("로그인 되어있지 않습니다.");
+
+            try {
+                ErrorResponse errorResponse = ErrorResponse.builder()
+                        .code(String.valueOf(HttpServletResponse.SC_UNAUTHORIZED))
+                        .message(CANNOT_FOUND_LOGIN_USER.getDescription())
+                        .build();
+
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+                response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+                response.getWriter().flush();
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    public void configureLogout(LogoutConfigurer<HttpSecurity> logout) throws AuthorizationDeniedException {
+        // 로그인 성공 메시지 작성
+        SuccessResponse<ResponseMessage> successResponse = SuccessResponse.of(LOGOUT_SUCCESS);
+        logout
+                .logoutUrl("/api/users/logout")  // 로그아웃 URL 설정
+                .addLogoutHandler(this)  // 커스텀 로그아웃 핸들러 추가
+                .logoutSuccessHandler((request, response, authentication) -> {
+                    if (!response.isCommitted()) {
+                        response.setContentType("application/json");
+                        response.setCharacterEncoding("UTF-8");
+                        response.getWriter().write(new ObjectMapper().writeValueAsString(successResponse));
+                        response.getWriter().flush();
+                    }
+                })
+                .permitAll();
     }
 
 }

--- a/src/main/java/com/bestcat/delivery/common/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bestcat/delivery/common/util/JwtAuthenticationFilter.java
@@ -1,7 +1,9 @@
 package com.bestcat.delivery.common.util;
 
-import static com.bestcat.delivery.common.type.ResponseMessage.SIGNIN_SUCCESS;
+import static com.bestcat.delivery.common.type.ErrorCode.SIGN_IN_FAILED;
+import static com.bestcat.delivery.common.type.ResponseMessage.SIGN_IN_SUCCESS;
 
+import com.bestcat.delivery.common.dto.ErrorResponse;
 import com.bestcat.delivery.common.dto.SuccessResponse;
 import com.bestcat.delivery.common.type.ResponseMessage;
 import com.bestcat.delivery.user.dto.SigninRequestDto;
@@ -57,7 +59,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String token = jwtUtil.createToken(id, username, role);
         jwtUtil.addJwtToCookie(token, response);
         // 로그인 성공 메시지 작성
-        SuccessResponse<ResponseMessage> successResponse = SuccessResponse.of(SIGNIN_SUCCESS);
+        SuccessResponse<ResponseMessage> successResponse = SuccessResponse.of(SIGN_IN_SUCCESS);
 
         // JSON 응답을 반환
         response.setContentType("application/json");
@@ -70,5 +72,13 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
         log.info("로그인 실패");
         response.setStatus(401);
+
+        // 로그인 실패 메시지 작성
+        ErrorResponse errorResponse = ErrorResponse.builder().code("UnAuthorized").message(SIGN_IN_FAILED.getDescription()).build();
+        // JSON 응답을 반환
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+        response.getWriter().flush();
     }
 }

--- a/src/main/java/com/bestcat/delivery/common/util/JwtUtil.java
+++ b/src/main/java/com/bestcat/delivery/common/util/JwtUtil.java
@@ -65,8 +65,6 @@ public class JwtUtil {
     // 로그 설정
     private static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
 
-    private final CustomLogoutHandler customLogoutHandler;
-
     // 여러번 요정되는 것을 방지
     @PostConstruct
     public void init() {
@@ -174,18 +172,5 @@ public class JwtUtil {
         return null;
     }
 
-    public void configureLogout(LogoutConfigurer<HttpSecurity> logout) throws AuthorizationDeniedException {
-        // 로그인 성공 메시지 작성
-        SuccessResponse<ResponseMessage> successResponse = SuccessResponse.of(LOGOUT_SUCCESS);
-        logout
-                .logoutUrl("/api/users/logout")  // 로그아웃 URL 설정
-                .addLogoutHandler(customLogoutHandler)  // 커스텀 로그아웃 핸들러 추가
-                .logoutSuccessHandler((request, response, authentication) -> {
-                    response.setContentType("application/json");
-                    response.setCharacterEncoding("UTF-8");
-                    response.getWriter().write(new ObjectMapper().writeValueAsString(successResponse));
-                    response.getWriter().flush();
-                })
-                .permitAll();
-    }
+
 }

--- a/src/main/java/com/bestcat/delivery/common/util/UserDetailsServiceImpl.java
+++ b/src/main/java/com/bestcat/delivery/common/util/UserDetailsServiceImpl.java
@@ -16,7 +16,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
+        User user = userRepository.findByUsernameAndDeletedAtIsNull(username)
                 .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
 
         return new UserDetailsImpl(user);

--- a/src/main/java/com/bestcat/delivery/review/repository/ReviewRepository.java
+++ b/src/main/java/com/bestcat/delivery/review/repository/ReviewRepository.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
-    Page<Review> findAllByOrderStoreStoreIdAndDeleteAtIsNull(UUID storeId, Pageable pageable);
+    Page<Review> findAllByOrderStoreStoreIdAndDeletedAtIsNull(UUID storeId, Pageable pageable);
 
-    Page<Review> findAllByUserIdAndDeleteAtIsNull(UUID userId, Pageable pageable);
+    Page<Review> findAllByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/bestcat/delivery/review/service/ReviewService.java
+++ b/src/main/java/com/bestcat/delivery/review/service/ReviewService.java
@@ -19,10 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -44,7 +42,7 @@ public class ReviewService {
 
         Page<Review> reviewList;
 
-        reviewList = reviewRepository.findAllByOrderStoreStoreIdAndDeleteAtIsNull(storeId, pageable);
+        reviewList = reviewRepository.findAllByOrderStoreStoreIdAndDeletedAtIsNull(storeId, pageable);
 
         return ResponseEntity.ok().body(reviewList.map(ReviewResponseDto::from));
     }
@@ -58,7 +56,7 @@ public class ReviewService {
 
         Page<Review> reviewList;
 
-        reviewList = reviewRepository.findAllByUserIdAndDeleteAtIsNull(userId, pageable);
+        reviewList = reviewRepository.findAllByUserIdAndDeletedAtIsNull(userId, pageable);
 
         return ResponseEntity.ok().body(reviewList.map(ReviewResponseDto::from));
     }

--- a/src/main/java/com/bestcat/delivery/user/dto/NicknameRequestDto.java
+++ b/src/main/java/com/bestcat/delivery/user/dto/NicknameRequestDto.java
@@ -1,0 +1,12 @@
+package com.bestcat.delivery.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+public record NicknameRequestDto(
+        @NotBlank
+        @Length(min = 2, max = 10, message = "최소 2글자, 최대 10글자 이내로 등록 가능합니다.")
+        String nickname
+) {
+}
+

--- a/src/main/java/com/bestcat/delivery/user/dto/PasswordRequestDto.java
+++ b/src/main/java/com/bestcat/delivery/user/dto/PasswordRequestDto.java
@@ -1,0 +1,17 @@
+package com.bestcat.delivery.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record PasswordRequestDto (
+        @NotBlank(message = "기존 비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*]*$", message = "알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자(!@#$%^&*) 만 입력 가능합니다.")
+        String password,
+
+        @NotBlank(message = "바꾸실 비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 20, message = "최소 8자 이상, 15자 이하의 글자만 입력할 수 있습니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*]*$", message = "알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자(!@#$%^&*) 만 입력 가능합니다.")
+        String newPassword
+) {
+}

--- a/src/main/java/com/bestcat/delivery/user/entity/User.java
+++ b/src/main/java/com/bestcat/delivery/user/entity/User.java
@@ -8,9 +8,11 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -42,6 +44,28 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RoleType role;
 
-    private boolean isPublic;
+    @Default
+    private boolean isPublic = true;
+
+    // 회원 가입 시 createdBy와 updatedBy에 회원 가입 된 유저 id 추가
+    @PrePersist
+    public void prePersist() {
+        if (getCreatedBy() == null) {
+            setCreatedBy(this.id);
+            setUpdatedBy(this.id);
+        }
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
 
 }

--- a/src/main/java/com/bestcat/delivery/user/repository/UserRepository.java
+++ b/src/main/java/com/bestcat/delivery/user/repository/UserRepository.java
@@ -12,7 +12,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     boolean existsByEmailAndDeletedAtIsNull(String email);
 
-    Optional<User> findByUsername(String username);
+    Optional<User> findByUsernameAndDeletedAtIsNull(String username);
 
     boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 }

--- a/src/main/java/com/bestcat/delivery/user/repository/UserRepository.java
+++ b/src/main/java/com/bestcat/delivery/user/repository/UserRepository.java
@@ -8,9 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByEmail(String email);
 
-    boolean existsByUsername(String username);
+    boolean existsByUsernameAndDeletedAtIsNull(String username);
 
-    boolean existsByNickname(String nickname);
+    boolean existsByEmailAndDeletedAtIsNull(String email);
 
     Optional<User> findByUsername(String username);
+
+    boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 }

--- a/src/main/java/com/bestcat/delivery/user/service/UserService.java
+++ b/src/main/java/com/bestcat/delivery/user/service/UserService.java
@@ -13,6 +13,8 @@ import com.bestcat.delivery.user.dto.SignupRequestDto;
 import com.bestcat.delivery.user.entity.RoleType;
 import com.bestcat.delivery.user.entity.User;
 import com.bestcat.delivery.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +60,7 @@ public class UserService {
         return requestDto.nickname();
     }
 
-    public void deleteUser(UUID userId, User user) {
+    public void deleteUser(UUID userId, User user, HttpServletResponse response) {
         validateUserIdIfNotAdminOrManager(userId, user);
 
         User userToDelete = userRepository.findById(userId).orElseThrow(() ->
@@ -67,6 +69,13 @@ public class UserService {
         userToDelete.updateDeleted();
 
         userRepository.save(userToDelete);
+
+        if(userId.equals(user.getId())) {
+            Cookie cookie = new Cookie("Authorization", null);
+            cookie.setMaxAge(0);
+            cookie.setPath("/");
+            response.addCookie(cookie);
+        }
     }
 
     public void updatePassword(UUID userId, User user, PasswordRequestDto requestDto) {

--- a/src/main/java/com/bestcat/delivery/user/service/UserService.java
+++ b/src/main/java/com/bestcat/delivery/user/service/UserService.java
@@ -1,8 +1,20 @@
 package com.bestcat.delivery.user.service;
 
+import static com.bestcat.delivery.common.type.ErrorCode.ALREADY_EXIST_NICKNAME;
+import static com.bestcat.delivery.common.type.ErrorCode.NEW_PASSWORD_SAME_AS_CURRENT;
+import static com.bestcat.delivery.common.type.ErrorCode.PASSWORD_MISMATCH;
+import static com.bestcat.delivery.common.type.ErrorCode.USER_ID_MISMATCH;
+import static com.bestcat.delivery.common.type.ErrorCode.USER_NOT_FOUND;
+
+import com.bestcat.delivery.common.exception.RestApiException;
+import com.bestcat.delivery.user.dto.NicknameRequestDto;
+import com.bestcat.delivery.user.dto.PasswordRequestDto;
 import com.bestcat.delivery.user.dto.SignupRequestDto;
+import com.bestcat.delivery.user.entity.RoleType;
 import com.bestcat.delivery.user.entity.User;
 import com.bestcat.delivery.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -33,18 +45,64 @@ public class UserService {
         userRepository.save(user);
     }
 
+    public String updateNickname(UUID userId, User user, @Valid NicknameRequestDto requestDto) {
+        validateUserIdIfNotAdminOrManager(userId, user);
 
+        if(checkNickname(requestDto.nickname())) {
+            throw new RestApiException(ALREADY_EXIST_NICKNAME);
+        }
+
+        user.updateNickname(requestDto.nickname());
+        userRepository.save(user);
+
+        return requestDto.nickname();
+    }
+
+    public void deleteUser(UUID userId, User user) {
+        validateUserIdIfNotAdminOrManager(userId, user);
+
+        User userToDelete = userRepository.findById(userId).orElseThrow(() ->
+                new RestApiException(USER_NOT_FOUND));
+
+        userToDelete.updateDeleted();
+
+        userRepository.save(userToDelete);
+    }
+
+    public void updatePassword(UUID userId, User user, PasswordRequestDto requestDto) {
+        if(!userId.equals(user.getId())) {
+            throw new RestApiException(USER_ID_MISMATCH);
+        }
+
+        if(requestDto.password().equals(requestDto.newPassword())) {
+            throw new RestApiException(NEW_PASSWORD_SAME_AS_CURRENT);
+        }
+
+        if(!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
+            throw new RestApiException(PASSWORD_MISMATCH);
+        }
+
+        user.updatePassword(passwordEncoder.encode(requestDto.newPassword()));
+
+        userRepository.save(user);
+    }
+
+    private void validateUserIdIfNotAdminOrManager(UUID userId, User user) {
+        if((user.getRole() == RoleType.CUSTOMER || user.getRole() == RoleType.OWNER) && !user.getId().equals(userId)) {
+            throw new RestApiException(USER_ID_MISMATCH);
+        }
+    }
 
     public boolean checkEmail(String email) {
-        return userRepository.existsByEmail(email);
+        return userRepository.existsByEmailAndDeletedAtIsNull(email);
     }
 
     public boolean checkUsername(String username) {
-        return userRepository.existsByUsername(username);
+        return userRepository.existsByUsernameAndDeletedAtIsNull(username);
     }
 
     public boolean checkNickname(String nickname) {
-        return userRepository.existsByNickname(nickname);
+        return userRepository.existsByNicknameAndDeletedAtIsNull(nickname);
     }
 
 }

--- a/src/main/java/com/bestcat/delivery/user/web/AuthController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/AuthController.java
@@ -5,9 +5,11 @@ import static com.bestcat.delivery.common.type.ResponseMessage.NICKNAME_CAN_USE;
 import static com.bestcat.delivery.common.type.ResponseMessage.USERNAME_CANT_USE;
 import static com.bestcat.delivery.common.type.ResponseMessage.USERNAME_CAN_USE;
 
+import com.bestcat.delivery.common.dto.ErrorResponse;
 import com.bestcat.delivery.common.dto.SuccessResponse;
 import com.bestcat.delivery.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,16 +22,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final UserService userService;
 
-    @GetMapping("/check-nickname")
-    public ResponseEntity<SuccessResponse<String>> checkNickname(@RequestParam(name = "nickname") String nickname) {
+    @GetMapping(value = "/check-nickname", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> checkNickname(@RequestParam(name = "nickname") String nickname) {
         return !userService.checkNickname(nickname) ? ResponseEntity.ok().body(SuccessResponse.of(NICKNAME_CAN_USE)) :
-                ResponseEntity.badRequest().body(SuccessResponse.of("FAIL", NICKNAME_CANT_USE));
+                ResponseEntity.badRequest().body(ErrorResponse.builder().code("FAIL").message(NICKNAME_CANT_USE.getMessage()).build());
     }
 
-    @GetMapping("/check-username")
-    public ResponseEntity<SuccessResponse<String>> checkUsername(@RequestParam(name = "username") String username) {
+    @GetMapping(value = "/check-username", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> checkUsername(@RequestParam(name = "username") String username) {
         return !userService.checkUsername(username) ? ResponseEntity.ok().body(SuccessResponse.of(USERNAME_CAN_USE)) :
-                ResponseEntity.badRequest().body(SuccessResponse.of("FAIL", USERNAME_CANT_USE));
+                ResponseEntity.badRequest().body(ErrorResponse.builder().code("FAIL").message(USERNAME_CANT_USE.getMessage()).build());
     }
 
 }

--- a/src/main/java/com/bestcat/delivery/user/web/AuthController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/AuthController.java
@@ -23,13 +23,13 @@ public class AuthController {
     @GetMapping("/check-nickname")
     public ResponseEntity<SuccessResponse<String>> checkNickname(@RequestParam(name = "nickname") String nickname) {
         return !userService.checkNickname(nickname) ? ResponseEntity.ok().body(SuccessResponse.of(NICKNAME_CAN_USE)) :
-                ResponseEntity.badRequest().body(SuccessResponse.of(NICKNAME_CANT_USE));
+                ResponseEntity.badRequest().body(SuccessResponse.of("FAIL", NICKNAME_CANT_USE));
     }
 
     @GetMapping("/check-username")
     public ResponseEntity<SuccessResponse<String>> checkUsername(@RequestParam(name = "username") String username) {
         return !userService.checkUsername(username) ? ResponseEntity.ok().body(SuccessResponse.of(USERNAME_CAN_USE)) :
-                ResponseEntity.badRequest().body(SuccessResponse.of(USERNAME_CANT_USE));
+                ResponseEntity.badRequest().body(SuccessResponse.of("FAIL", USERNAME_CANT_USE));
     }
 
 }

--- a/src/main/java/com/bestcat/delivery/user/web/AuthController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/AuthController.java
@@ -1,0 +1,35 @@
+package com.bestcat.delivery.user.web;
+
+import static com.bestcat.delivery.common.type.ResponseMessage.NICKNAME_CANT_USE;
+import static com.bestcat.delivery.common.type.ResponseMessage.NICKNAME_CAN_USE;
+import static com.bestcat.delivery.common.type.ResponseMessage.USERNAME_CANT_USE;
+import static com.bestcat.delivery.common.type.ResponseMessage.USERNAME_CAN_USE;
+
+import com.bestcat.delivery.common.dto.SuccessResponse;
+import com.bestcat.delivery.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final UserService userService;
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<SuccessResponse<String>> checkNickname(@RequestParam(name = "nickname") String nickname) {
+        return !userService.checkNickname(nickname) ? ResponseEntity.ok().body(SuccessResponse.of(NICKNAME_CAN_USE)) :
+                ResponseEntity.badRequest().body(SuccessResponse.of(NICKNAME_CANT_USE));
+    }
+
+    @GetMapping("/check-username")
+    public ResponseEntity<SuccessResponse<String>> checkUsername(@RequestParam(name = "username") String username) {
+        return !userService.checkUsername(username) ? ResponseEntity.ok().body(SuccessResponse.of(USERNAME_CAN_USE)) :
+                ResponseEntity.badRequest().body(SuccessResponse.of(USERNAME_CANT_USE));
+    }
+
+}

--- a/src/main/java/com/bestcat/delivery/user/web/UserController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/UserController.java
@@ -14,6 +14,7 @@ import com.bestcat.delivery.user.dto.PasswordRequestDto;
 import com.bestcat.delivery.user.dto.SignupRequestDto;
 import com.bestcat.delivery.user.dto.UserInfoDto;
 import com.bestcat.delivery.user.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -54,9 +55,10 @@ public class UserController {
     @DeleteMapping("/{userId}")
     @Secured({"ROLE_MASTER", "ROLE_MANAGER", "ROLE_OWNER", "ROLE_CUSTOMER"})
     public ResponseEntity<SuccessResponse<String>> deleteUser(
-            @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID userId) {
+            @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID userId,
+            HttpServletResponse response) {
 
-        userService.deleteUser(userId, userDetails.getUser());
+        userService.deleteUser(userId, userDetails.getUser(), response);
         return ResponseEntity.ok(SuccessResponse.of(DELETE_USER_SUCCESS));
     }
 

--- a/src/main/java/com/bestcat/delivery/user/web/UserController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/UserController.java
@@ -1,21 +1,29 @@
 package com.bestcat.delivery.user.web;
 
+import static com.bestcat.delivery.common.type.ResponseMessage.DELETE_USER_SUCCESS;
 import static com.bestcat.delivery.common.type.ResponseMessage.GET_USER_INFO_SUCCESS;
-import static com.bestcat.delivery.common.type.ResponseMessage.SIGNIN_SUCCESS;
-import static com.bestcat.delivery.common.type.ResponseMessage.SIGNUP_SUCCESS;
+import static com.bestcat.delivery.common.type.ResponseMessage.NICKNAME_UPDATE_SUCCESS;
+import static com.bestcat.delivery.common.type.ResponseMessage.PASSWORD_UPDATE_SUCCESS;
+import static com.bestcat.delivery.common.type.ResponseMessage.SIGN_UP_SUCCESS;
 
 import com.bestcat.delivery.common.dto.SuccessResponse;
 import com.bestcat.delivery.common.type.ResponseMessage;
 import com.bestcat.delivery.common.util.UserDetailsImpl;
+import com.bestcat.delivery.user.dto.NicknameRequestDto;
+import com.bestcat.delivery.user.dto.PasswordRequestDto;
 import com.bestcat.delivery.user.dto.SignupRequestDto;
 import com.bestcat.delivery.user.dto.UserInfoDto;
 import com.bestcat.delivery.user.service.UserService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,16 +37,49 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<SuccessResponse<ResponseMessage>> signup(@Valid @RequestBody SignupRequestDto requestDto) {
-        userService.signup(requestDto);
+    public ResponseEntity<SuccessResponse<ResponseMessage>> signup(
+            @Valid @RequestBody SignupRequestDto requestDto) {
 
-        return ResponseEntity.ok(SuccessResponse.of(SIGNUP_SUCCESS));
+        userService.signup(requestDto);
+        return ResponseEntity.ok(SuccessResponse.of(SIGN_UP_SUCCESS));
     }
 
     @GetMapping
-    public ResponseEntity<SuccessResponse<UserInfoDto>> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseEntity.ok().body(
-                SuccessResponse.of(GET_USER_INFO_SUCCESS, new UserInfoDto(userDetails)));
+    public ResponseEntity<SuccessResponse<UserInfoDto>> getUserInfo(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        return ResponseEntity.ok().body(SuccessResponse.of(GET_USER_INFO_SUCCESS, new UserInfoDto(userDetails)));
     }
+
+    @DeleteMapping("/{userId}")
+    @Secured({"ROLE_MASTER", "ROLE_MANAGER", "ROLE_OWNER", "ROLE_CUSTOMER"})
+    public ResponseEntity<SuccessResponse<String>> deleteUser(
+            @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID userId) {
+
+        userService.deleteUser(userId, userDetails.getUser());
+        return ResponseEntity.ok(SuccessResponse.of(DELETE_USER_SUCCESS));
+    }
+
+    @PatchMapping("/{userId}/password")
+    @Secured({"ROLE_MASTER", "ROLE_MANAGER", "ROLE_OWNER", "ROLE_CUSTOMER"})
+    public ResponseEntity<SuccessResponse<String>> updatePassword(
+            @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID userId,
+            @RequestBody @Valid PasswordRequestDto requestDto) {
+
+        userService.updatePassword(userId, userDetails.getUser(), requestDto);
+        return ResponseEntity.ok(SuccessResponse.of(PASSWORD_UPDATE_SUCCESS));
+    }
+
+    @PatchMapping("/{userId}/nickname")
+    @Secured({"ROLE_MASTER", "ROLE_MANAGER", "ROLE_OWNER", "ROLE_CUSTOMER"})
+    public ResponseEntity<SuccessResponse<String>> updateNickname(
+            @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID userId,
+            @RequestBody @Valid NicknameRequestDto nickname) {
+
+        return ResponseEntity.ok(SuccessResponse.of(
+                NICKNAME_UPDATE_SUCCESS, userService.updateNickname(userId, userDetails.getUser(), nickname)
+        ));
+    }
+
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #15 

## 📝작업 내용

> 유저 관련 기능 추가(/api/users)
- 유저 닉네임, 비밀번호 업데이트
- 유저 삭제 
  -  deletedBy와 deletedAt이 업데이트 됩니다.
  - 로그인 한 회원과 삭제한 id 값이 같을 경우 쿠키에서 Authorization에 null을 넣어서 로그아웃 되도록 합니다.
- 로그아웃
  - 로그아웃 url로 post 요청 시 filter 를 통해 CustomLogoutHandler 동작 후 쿠키의 Authorization 값을 null로 반환
  - 로그인 되어있지 않다면 401 에러 메세지를 띄워줍니다.
![image](https://github.com/user-attachments/assets/8e31120a-a8bd-438b-a266-33e2568a3a64)
  - response.isCommitted() 메서드를 활용하여 response에 이미 실패 메세지가 담겨있는 경우 성공 메세지를 담지 않고, 넘어가도록 작성하였습니다.

> Auth 관련 기능 추가(/api/auth)
- ResponseEntity를 와일드카드로 작성하여 중복된 아이디나 닉네임이 있다면 ErrorResponse를 반환하고 없다면 SuccessResponse 를 반환하도록 하였습니다.
  ![image](https://github.com/user-attachments/assets/84f92072-f15d-45c1-b3b3-28d4aa5eb0b6)
- 닉네임, 아이디 중복 확인 여부
> 유저 관련 조회 시  DeletedAtIsNull 을 메서드에 추가하여 삭제된 유저에 대해선 조회 되지 않도록 변경했습니다.

> 로그인 시  DeletedAtIsNull 을 메서드에 추가하여 삭제된 유저에 대해선 로그인 되지 않도록 변경했습니다.


## 💬리뷰 요구사항(선택)
- 궁금하신 부분 편하게 물어봐주세요!