### PR TITLE
feat: 주문 기능 추가

### DIFF
--- a/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
+++ b/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     // delivery
     DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 배달 주소를 찾을 수 없습니다."),
 
+    // store
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가게를 찾을 수 없습니다."),
 
     // 다른 도메인 추가...
 

--- a/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
+++ b/src/main/java/com/bestcat/delivery/common/type/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    INVALID_ROLE(HttpStatus.NOT_FOUND, "유효한 권한이 아닙니다."),
 
 
     // area
@@ -31,6 +32,11 @@ public enum ErrorCode {
 
     // store
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가게를 찾을 수 없습니다."),
+
+    // order
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태입니다."),
+
 
     // 다른 도메인 추가...
 

--- a/src/main/java/com/bestcat/delivery/order/dto/request/OrderCreationRequest.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/request/OrderCreationRequest.java
@@ -1,14 +1,14 @@
 package com.bestcat.delivery.order.dto.request;
 
+import com.bestcat.delivery.order.entity.type.OrderType;
 import java.util.List;
 import java.util.UUID;
 
 public record OrderCreationRequest(
         UUID storeId,
-        String orderType, // ONLINE, IN_PERSON
+        OrderType orderType, // ONLINE, IN_PERSON
         String address,
         String requestNotes,
         List<OrderItemRequest> items
-
 ) {
 }

--- a/src/main/java/com/bestcat/delivery/order/dto/request/OrderCreationRequest.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/request/OrderCreationRequest.java
@@ -1,0 +1,14 @@
+package com.bestcat.delivery.order.dto.request;
+
+import java.util.List;
+import java.util.UUID;
+
+public record OrderCreationRequest(
+        UUID storeId,
+        String orderType, // ONLINE, IN_PERSON
+        String address,
+        String requestNotes,
+        List<OrderItemRequest> items
+
+) {
+}

--- a/src/main/java/com/bestcat/delivery/order/dto/request/OrderItemRequest.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/request/OrderItemRequest.java
@@ -1,0 +1,9 @@
+package com.bestcat.delivery.order.dto.request;
+
+import java.util.UUID;
+
+public record OrderItemRequest(
+        UUID menuId,
+        int quantity
+) {
+}

--- a/src/main/java/com/bestcat/delivery/order/dto/request/OrderStatusUpdateRequest.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/request/OrderStatusUpdateRequest.java
@@ -1,7 +1,9 @@
 package com.bestcat.delivery.order.dto.request;
 
+import com.bestcat.delivery.order.entity.type.OrderStatus;
+
 public record OrderStatusUpdateRequest(
-        String status, // RECEIVED, CANCELLED, COMPLETED
+        OrderStatus status, // RECEIVED, CANCELLED, COMPLETED
         String updatedBy
 ) {
 }

--- a/src/main/java/com/bestcat/delivery/order/dto/request/OrderStatusUpdateRequest.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/request/OrderStatusUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.bestcat.delivery.order.dto.request;
+
+public record OrderStatusUpdateRequest(
+        String status, // RECEIVED, CANCELLED, COMPLETED
+        String updatedBy
+) {
+}

--- a/src/main/java/com/bestcat/delivery/order/dto/response/OrderCancelResponse.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/response/OrderCancelResponse.java
@@ -1,0 +1,20 @@
+package com.bestcat.delivery.order.dto.response;
+
+import com.bestcat.delivery.order.entity.OrderCancellations;
+import java.util.UUID;
+
+public record OrderCancelResponse(
+        UUID cancellationId,
+        UUID userId,
+        UUID orderId,
+        String cancelReason
+) {
+
+    public static OrderCancelResponse fromEntity(OrderCancellations orderCancellations) {
+        return new OrderCancelResponse(
+                orderCancellations.getCancellationId(),
+                orderCancellations.getUser().getId(),
+                orderCancellations.getOrder().getOrderId(),
+                orderCancellations.getCancelReason());
+    }
+}

--- a/src/main/java/com/bestcat/delivery/order/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/response/OrderItemResponse.java
@@ -1,0 +1,21 @@
+package com.bestcat.delivery.order.dto.response;
+
+import com.bestcat.delivery.menu.entity.Menu;
+import com.bestcat.delivery.order.entity.OrderItems;
+import java.util.UUID;
+
+public record OrderItemResponse(
+        UUID orderItemId,
+        UUID menuId,
+        int quantity,
+        double price
+) {
+    public static OrderItemResponse fromEntity(OrderItems items) {
+        return new OrderItemResponse(
+                items.getOrderItemsId(),
+                items.getMenu().getId(),
+                items.getQuantity(),
+                items.getPrice()
+        );
+    }
+}

--- a/src/main/java/com/bestcat/delivery/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/response/OrderResponse.java
@@ -1,0 +1,37 @@
+package com.bestcat.delivery.order.dto.response;
+
+import com.bestcat.delivery.order.entity.Order;
+import com.bestcat.delivery.order.entity.OrderItems;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderResponse(
+        UUID orderId,
+        UUID userId,
+        UUID storeId,
+        String orderType,
+        String status,
+        String address,
+        String requestNotes,
+        Timestamp createdAt,
+        Timestamp updatedAt,
+        double totalPrice, // 총 가격
+        List<OrderItems> items
+) {
+    public static OrderResponse fromEntity(Order order, double totalPrice, List<OrderItems> items) {
+        return new OrderResponse(
+                order.getOrderId(),
+                order.getUser().getId(),
+                order.getStore().getStoreId(),
+                order.getOrderType().name(),
+                order.getStatus().name(),
+                order.getAddress(),
+                order.getRequestNotes(),
+                order.getCreatedAt(),
+                order.getUpdateAt(),
+                totalPrice,
+                items
+        );
+    }
+}

--- a/src/main/java/com/bestcat/delivery/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/bestcat/delivery/order/dto/response/OrderResponse.java
@@ -5,6 +5,7 @@ import com.bestcat.delivery.order.entity.OrderItems;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public record OrderResponse(
         UUID orderId,
@@ -17,9 +18,13 @@ public record OrderResponse(
         Timestamp createdAt,
         Timestamp updatedAt,
         double totalPrice, // 총 가격
-        List<OrderItems> items
+        List<OrderItemResponse> items
 ) {
     public static OrderResponse fromEntity(Order order, double totalPrice, List<OrderItems> items) {
+        List<OrderItemResponse> itemResponses = items.stream()
+                .map(OrderItemResponse::fromEntity)
+                .toList();
+
         return new OrderResponse(
                 order.getOrderId(),
                 order.getUser().getId(),
@@ -31,7 +36,7 @@ public record OrderResponse(
                 order.getCreatedAt(),
                 order.getUpdateAt(),
                 totalPrice,
-                items
+                itemResponses
         );
     }
 }

--- a/src/main/java/com/bestcat/delivery/order/entity/Order.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/Order.java
@@ -1,7 +1,9 @@
 package com.bestcat.delivery.order.entity;
 
+import com.bestcat.delivery.common.entity.BaseEntity;
 import com.bestcat.delivery.order.entity.type.OrderStatus;
 import com.bestcat.delivery.order.entity.type.OrderType;
+import com.bestcat.delivery.store.entity.Store;
 import com.bestcat.delivery.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,7 +28,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class Order {
+public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name ="order_id",updatable = false, nullable = false)
@@ -36,9 +38,9 @@ public class Order {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "store_id", nullable = false)
-//    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "order_type", nullable = false, length = 20)
@@ -53,7 +55,5 @@ public class Order {
 
     @Column(name = "request_notes")
     private String requestNotes;
-
-    //BaseEntity
 
 }

--- a/src/main/java/com/bestcat/delivery/order/entity/Order.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/Order.java
@@ -5,6 +5,7 @@ import com.bestcat.delivery.order.entity.type.OrderStatus;
 import com.bestcat.delivery.order.entity.type.OrderType;
 import com.bestcat.delivery.store.entity.Store;
 import com.bestcat.delivery.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,7 +16,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,7 +35,7 @@ import lombok.NoArgsConstructor;
 public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name ="order_id",updatable = false, nullable = false)
+    @Column(name = "order_id", updatable = false, nullable = false)
     private UUID orderId;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -56,4 +60,19 @@ public class Order extends BaseEntity {
     @Column(name = "request_notes")
     private String requestNotes;
 
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "order_id")
+    private List<OrderItems> orderItems = new ArrayList<>();
+
+    public void addOrderItem(OrderItems item) {
+        orderItems.add(item);
+    }
+
+    public void cancelOrder() {
+        this.status = OrderStatus.CANCELLED;
+    }
+
+    public void updateOrderStatus(OrderStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/bestcat/delivery/order/entity/OrderCancellations.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/OrderCancellations.java
@@ -1,7 +1,8 @@
 package com.bestcat.delivery.order.entity;
 
+
 import com.bestcat.delivery.common.entity.BaseEntity;
-import com.bestcat.delivery.menu.entity.Menu;
+import com.bestcat.delivery.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -17,26 +18,28 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "p_order_items")
+@Table(name = "p_order_cancellations")
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class OrderItems extends BaseEntity {
+public class OrderCancellations extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name ="order_items_id",updatable = false, nullable = false)
-    private UUID orderItemsId;
+    @Column(name ="cancellation_id",updatable = false, nullable = false)
+    private UUID cancellationId;
 
     @ManyToOne
-    @JoinColumn(name = "menu_id", nullable = false)
-    private Menu menu;
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
 
-    @Column(nullable = false)
-    private Integer quantity; // 메뉴 수량
+    @ManyToOne
+    @JoinColumn(name = "user_id",  nullable = false)
+    private User user;
 
-    @Column(nullable = false, precision = 10, scale = 2)
-    private Integer price; // 메뉴 가격
+    @Column(name = "cancel_reason", nullable = false)
+    private String cancelReason;
+
 
 }

--- a/src/main/java/com/bestcat/delivery/order/entity/OrderItems.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/OrderItems.java
@@ -1,0 +1,46 @@
+package com.bestcat.delivery.order.entity;
+
+import com.bestcat.delivery.common.entity.BaseEntity;
+import com.bestcat.delivery.menu.entity.Menu;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_order_items")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderItems extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name ="order_id",updatable = false, nullable = false)
+    private UUID orderItemsId;
+
+    @ManyToOne
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @Column(nullable = false)
+    private Integer quantity; // 메뉴 수량
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private Integer price; // 메뉴 가격
+
+}

--- a/src/main/java/com/bestcat/delivery/order/entity/type/OrderStatus.java
+++ b/src/main/java/com/bestcat/delivery/order/entity/type/OrderStatus.java
@@ -1,6 +1,7 @@
 package com.bestcat.delivery.order.entity.type;
 
 public enum OrderStatus {
+    DEFAULT,
     RECEIVED,
     CANCELLED,
     COMPLETED

--- a/src/main/java/com/bestcat/delivery/order/repository/OrderRepository.java
+++ b/src/main/java/com/bestcat/delivery/order/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.bestcat.delivery.order.repository;
+
+import com.bestcat.delivery.order.entity.Order;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+
+}

--- a/src/main/java/com/bestcat/delivery/order/repository/OrderRepository.java
+++ b/src/main/java/com/bestcat/delivery/order/repository/OrderRepository.java
@@ -1,11 +1,19 @@
 package com.bestcat.delivery.order.repository;
 
 import com.bestcat.delivery.order.entity.Order;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, UUID> {
 
+    @Query("select o from Order o join fetch o.i")
+    List<Order> findByUserId(@Param("userId") UUID userId);
+
+    @Query("select o from Order o join o.store s where s.owner.id = :ownerId")
+    List<Order> findByStoreOwnerId(@Param("ownerId") UUID ownerId);
 }

--- a/src/main/java/com/bestcat/delivery/order/service/OrderService.java
+++ b/src/main/java/com/bestcat/delivery/order/service/OrderService.java
@@ -1,0 +1,75 @@
+package com.bestcat.delivery.order.service;
+
+import static java.awt.SystemColor.menu;
+
+import com.bestcat.delivery.common.dto.ErrorResponse;
+import com.bestcat.delivery.common.exception.GlobalExceptionHandler;
+import com.bestcat.delivery.common.exception.RestApiException;
+import com.bestcat.delivery.common.type.ErrorCode;
+import com.bestcat.delivery.menu.entity.Menu;
+import com.bestcat.delivery.order.dto.request.OrderCreationRequest;
+import com.bestcat.delivery.order.dto.response.OrderItemResponse;
+import com.bestcat.delivery.order.dto.response.OrderResponse;
+import com.bestcat.delivery.order.entity.Order;
+import com.bestcat.delivery.order.entity.OrderItems;
+import com.bestcat.delivery.order.entity.type.OrderStatus;
+import com.bestcat.delivery.order.entity.type.OrderType;
+import com.bestcat.delivery.order.repository.OrderRepository;
+import com.bestcat.delivery.store.entity.Store;
+import com.bestcat.delivery.user.entity.User;
+import com.bestcat.delivery.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+   // private final MenuRepository menuRepository;
+    //private final StoreRepository storeRepository;
+
+    public OrderResponse createOrder(OrderCreationRequest request, UUID userId){
+       User user = userRepository.findById(userId).orElseThrow(()
+               -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+//        Store store = storeRepository.findById(request.storeId()).orElseThrow(()
+//                -> new RestApiException(ErrorCode.STORE_NOT_FOUND));
+
+        Store 임시코드 = new Store(); // TODO StoreRepository 생성 되면 수정
+
+        Order order = Order.builder()
+                .user(user)
+                .store(임시코드)
+                .orderType(OrderType.valueOf(request.orderType()))
+                .status(OrderStatus.RECEIVED)
+                .address(request.address())
+                .requestNotes(request.requestNotes())
+                .build();
+        List<OrderItems> orderItems = request.items().stream().map(itemRequest -> {
+            //Menu menu = menuRepository.findById(itemRequest.menuId());
+            Menu 임시코드02 = new Menu();
+            return OrderItems.builder()
+                    .order(order)
+                    .menu(임시코드02)
+                    .quantity(itemRequest.quantity())
+                    .price(임시코드02.getPrice() * itemRequest.quantity())
+                    .build();
+        }).collect(Collectors.toList());
+
+        // 총 가격 계산
+        double totalPrice = orderItems.stream()
+                .mapToDouble(OrderItems::getPrice)
+                .sum();
+
+        Order savedOrder = orderRepository.save(order);
+        return OrderResponse.fromEntity(savedOrder, totalPrice, orderItems);
+    }
+
+
+}

--- a/src/main/java/com/bestcat/delivery/order/service/OrderService.java
+++ b/src/main/java/com/bestcat/delivery/order/service/OrderService.java
@@ -1,29 +1,28 @@
 package com.bestcat.delivery.order.service;
 
-import static java.awt.SystemColor.menu;
-
-import com.bestcat.delivery.common.dto.ErrorResponse;
-import com.bestcat.delivery.common.exception.GlobalExceptionHandler;
 import com.bestcat.delivery.common.exception.RestApiException;
 import com.bestcat.delivery.common.type.ErrorCode;
 import com.bestcat.delivery.menu.entity.Menu;
 import com.bestcat.delivery.order.dto.request.OrderCreationRequest;
-import com.bestcat.delivery.order.dto.response.OrderItemResponse;
+import com.bestcat.delivery.order.dto.request.OrderStatusUpdateRequest;
+import com.bestcat.delivery.order.dto.response.OrderCancelResponse;
 import com.bestcat.delivery.order.dto.response.OrderResponse;
 import com.bestcat.delivery.order.entity.Order;
+import com.bestcat.delivery.order.entity.OrderCancellations;
 import com.bestcat.delivery.order.entity.OrderItems;
 import com.bestcat.delivery.order.entity.type.OrderStatus;
 import com.bestcat.delivery.order.entity.type.OrderType;
 import com.bestcat.delivery.order.repository.OrderRepository;
 import com.bestcat.delivery.store.entity.Store;
+import com.bestcat.delivery.user.entity.RoleType;
 import com.bestcat.delivery.user.entity.User;
 import com.bestcat.delivery.user.repository.UserRepository;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.aspectj.weaver.ast.Or;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,12 +30,20 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
-   // private final MenuRepository menuRepository;
+    // private final MenuRepository menuRepository;
     //private final StoreRepository storeRepository;
 
-    public OrderResponse createOrder(OrderCreationRequest request, UUID userId){
-       User user = userRepository.findById(userId).orElseThrow(()
-               -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+    /**
+     * 주문을 생성하는 메서드
+     *
+     * @param request 주문 생성 요청 데이터
+     * @param userId  주문을 생성하는 사용자 ID
+     * @return 생성된 주문 정보(OrderResponse)
+     */
+    @Transactional
+    public OrderResponse createOrder(OrderCreationRequest request, UUID userId) {
+        User user = getUser(userId);
 
 //        Store store = storeRepository.findById(request.storeId()).orElseThrow(()
 //                -> new RestApiException(ErrorCode.STORE_NOT_FOUND));
@@ -46,29 +53,157 @@ public class OrderService {
         Order order = Order.builder()
                 .user(user)
                 .store(임시코드)
-                .orderType(OrderType.valueOf(request.orderType()))
-                .status(OrderStatus.RECEIVED)
+                .orderType(request.orderType())
+                .status(OrderStatus.DEFAULT)
                 .address(request.address())
                 .requestNotes(request.requestNotes())
                 .build();
+
         List<OrderItems> orderItems = request.items().stream().map(itemRequest -> {
             //Menu menu = menuRepository.findById(itemRequest.menuId());
-            Menu 임시코드02 = new Menu();
-            return OrderItems.builder()
-                    .order(order)
+            Menu 임시코드02 = new Menu(); // TODO MenuRepository 생성 되면 수정
+
+            OrderItems item = OrderItems.builder()
                     .menu(임시코드02)
                     .quantity(itemRequest.quantity())
                     .price(임시코드02.getPrice() * itemRequest.quantity())
                     .build();
-        }).collect(Collectors.toList());
-
-        // 총 가격 계산
-        double totalPrice = orderItems.stream()
-                .mapToDouble(OrderItems::getPrice)
-                .sum();
+            order.addOrderItem(item);
+            return item;
+        }).toList();
 
         Order savedOrder = orderRepository.save(order);
+
+        // 총 가격 계산
+        double totalPrice = getTotalOrderPrice(orderItems);
+
         return OrderResponse.fromEntity(savedOrder, totalPrice, orderItems);
+    }
+
+    /**
+     * 주문 상세 조회
+     *
+     * @param orderId
+     * @param userId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public OrderResponse getOrder(UUID orderId, UUID userId) {
+        User user = getUser(userId);
+        Order order = getOrder(orderId);
+
+        // 요구사항_권한 확인: 고객은 자신의 주문만, 가게 주인은 자신의 가게 주문만 조회 가능
+        if (user.getRole().equals(RoleType.CUSTOMER) && !order.getUser().getId().equals(userId)) {
+            throw new RestApiException(ErrorCode.UNAUTHORIZED);
+        } else if (user.getRole().equals(RoleType.OWNER) && !order.getStore().getOwner().getId()
+                .equals(userId)) {
+            throw new RestApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return OrderResponse.fromEntity(order, getTotalOrderPrice(order.getOrderItems()),
+                order.getOrderItems());
+    }
+
+    /**
+     * 주문 리스트 조회
+     *
+     * @param userId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public List<OrderResponse> getOrders(UUID userId) {
+        User user = getUser(userId);
+        List<Order> orders;
+        if (user.getRole().equals(RoleType.CUSTOMER)) {
+            orders = orderRepository.findByUserId(user.getId());
+        } else if (user.getRole().equals(RoleType.OWNER)) {
+            orders = orderRepository.findByStoreOwnerId(userId);
+        } else {
+            throw new RestApiException(ErrorCode.INVALID_ROLE);
+        }
+
+        return orders.stream()
+                .map(order -> {
+                    double totalPrice = getTotalOrderPrice(order.getOrderItems());
+
+                    return OrderResponse.fromEntity(order, totalPrice, order.getOrderItems());
+                }).toList();
+
+    }
+
+    /**
+     * 주문 취소
+     *
+     * @param orderId
+     * @param userId
+     * @param cancelReason
+     * @return
+     */
+    @Transactional
+    public OrderCancelResponse cancelOrder(UUID orderId, UUID userId, String cancelReason) {
+        Order order = getOrder(orderId);
+
+        // 요구사항_권한 확인: 고객만 자신의 주문을 취소할 수 있음
+        if (!order.getUser().getId().equals(userId)) {
+            throw new RestApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 요구사항_RECEIVED 상태에서만 취소 가능
+        if (order.getStatus() != OrderStatus.RECEIVED) {
+            throw new RestApiException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+
+        order.cancelOrder();
+        OrderCancellations orderCancellations = OrderCancellations.builder()
+                .order(order)
+                .cancelReason(cancelReason)
+                .build();
+
+        orderRepository.save(order);
+
+        return OrderCancelResponse.fromEntity(orderCancellations);
+    }
+
+    /**
+     * 주문 상태 변경
+     *
+     * @param orderId
+     * @param userId
+     * @param request
+     * @return
+     */
+    @Transactional
+    public OrderResponse updateOrderStatus(UUID orderId, UUID userId,
+                                           OrderStatusUpdateRequest request) {
+        Order order = getOrder(orderId);
+
+        // 요구사항_권한 확인: 가게 주인만 상태 변경 가능
+        if (!order.getStore().getOwner().getId().equals(userId)) {
+            throw new RestApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        order.updateOrderStatus(request.status());
+
+        Order savedOrder = orderRepository.save(order);
+
+        return OrderResponse.fromEntity(savedOrder,
+                getTotalOrderPrice(savedOrder.getOrderItems()), savedOrder.getOrderItems());
+
+    }
+
+
+    private Order getOrder(UUID orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.ORDER_NOT_FOUND));
+    }
+
+    private static double getTotalOrderPrice(List<OrderItems> orderItems) {
+        return orderItems.stream().mapToDouble(OrderItems::getPrice).sum();
+    }
+
+    private User getUser(UUID userId) {
+        return userRepository.findById(userId).orElseThrow(()
+                -> new RestApiException(ErrorCode.USER_NOT_FOUND));
     }
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호
#8 

## 📝 작업 내용

1. **DTO 추가**:
   - `OrderCreationRequest`: 주문 생성 요청 객체
   - `OrderResponse`: 주문 생성 응답 객체
   - `OrderItemRequest`: 주문 항목 요청 객체
   - `OrderItemResponse`: 주문 항목 응답 객체
   - `OrderStatusUpdateRequest`: 주문 상태 변경 요청 객체

2. **엔티티 추가**:
   - `Order`: 주문 정보
   - `OrderItems`: 주문 항목 정보

3. **서비스 구현**:
   - `OrderService`:
     - 주문 생성 기능 구현
     - 사용자 및 스토어 검증 로직 추가
     - 주문 항목 계산 및 총 가격 로직 포함

4. **레포지토리 추가**:
   - `OrderRepository`: 주문 데이터 저장 및 조회를 위한 레포지토리

5. **에러 코드 추가**:
   - `ErrorCode`에 스토어 관련 에러 코드 추가:
     - `STORE_NOT_FOUND`: 해당 스토어를 찾을 수 없는 경우 처리

6. **기타**:
   - 임시 코드로 `Store`와 `Menu`를 하드코딩하여 사용 (TODO: 관련 레포지토리 추가 후 수정 필요)

---

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성합니다.

- **DTO 설계**:
  - `OrderCreationRequest`와 `OrderResponse`의 필드 구성이 적절한지 확인 부탁드립니다.
  - `OrderItemRequest` 및 `OrderItemResponse`에서 추가로 필요한 필드가 있을지 의견 주시면 감사하겠습니다.

- **서비스 구현**:
 - createOrder 메서드에서 Store와 Menu를 임시 객체로 대체한 부분을 Repository로 수정할 예정입니다.

- **기타**:
  - 엔티티 `Order`와 `OrderItems`의 설계가 충분히 유연한지 검토 부탁드립니다.
  - 에러 코드 및 예외 처리가 실무에 적합한지 확인 부탁드립니다.

---

### 스크린샷 또는 코드 스니펫 (선택)

> 예를 들어, 테스트 결과나 주요 코드 부분을 캡처하여 첨부할 수 있습니다.

---