### PR TITLE
[FEAT] MASTER, MANAGER 유저의 일반 유저 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ out/
 
 application.yml
 
-/build/generated/
+$buildDir/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ out/
 application.yml
 
 $buildDir/
+src/main/generated/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ out/
 .DS_store
 
 application.yml
+
+/build/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,15 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.6'
 }
 
+def querydslVersion = '5.0.0'
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+
 group = 'com.best-cat'
 version = '0.0.1-SNAPSHOT'
 
@@ -51,7 +60,15 @@ dependencies {
 
     // http 요청
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
+
+
+def querydslDir = '$buildDir/generated/querydsl'
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/bestcat/delivery/common/config/JpaConfig.java
+++ b/src/main/java/com/bestcat/delivery/common/config/JpaConfig.java
@@ -1,9 +1,20 @@
 package com.bestcat.delivery.common.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")  // AuditorAware 구현체 지정
 public class JpaConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/src/main/java/com/bestcat/delivery/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/bestcat/delivery/common/config/WebSecurityConfig.java
@@ -76,6 +76,7 @@ public class WebSecurityConfig {
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/api/users/signin", "/api/users/signup", "/api/auth/*").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
+                        .requestMatchers("/api/admins/**").hasAnyRole("MASTER", "MANAGER")
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         ).logout(customLogoutHandler::configureLogout);
 

--- a/src/main/java/com/bestcat/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bestcat/delivery/common/exception/GlobalExceptionHandler.java
@@ -66,7 +66,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
         log.error("IllegalArgumentException occurred", e);
-        return handleExceptionInternal(BAD_REQUEST);
+        return ResponseEntity.badRequest().body(e.getMessage());
     }
 
     /**

--- a/src/main/java/com/bestcat/delivery/user/dto/UserDetailsInfoDto.java
+++ b/src/main/java/com/bestcat/delivery/user/dto/UserDetailsInfoDto.java
@@ -1,0 +1,26 @@
+package com.bestcat.delivery.user.dto;
+
+import com.bestcat.delivery.user.entity.RoleType;
+import com.bestcat.delivery.user.entity.User;
+import java.util.UUID;
+
+public record UserDetailsInfoDto(
+        UUID id,
+        String username,
+        String email,
+        String nickname,
+        RoleType role,
+        boolean isPublic
+) {
+
+    public UserDetailsInfoDto(User user) {
+        this(user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole(),
+                user.isPublic())
+        ;
+    }
+
+}

--- a/src/main/java/com/bestcat/delivery/user/dto/UserInfoDto.java
+++ b/src/main/java/com/bestcat/delivery/user/dto/UserInfoDto.java
@@ -1,15 +1,18 @@
 package com.bestcat.delivery.user.dto;
 
 import com.bestcat.delivery.user.entity.User;
+import java.util.UUID;
 
 public record UserInfoDto (
+        UUID id,
         String username,
         String email,
         String nickname
 ){
     public UserInfoDto(User user) {
-        this(user.getUsername(),
-                user.getEmail(),
-                user.getNickname());
+        this(user.getId(),
+            user.getUsername(),
+            user.getEmail(),
+            user.getNickname());
     }
 }

--- a/src/main/java/com/bestcat/delivery/user/entity/SortType.java
+++ b/src/main/java/com/bestcat/delivery/user/entity/SortType.java
@@ -1,0 +1,5 @@
+package com.bestcat.delivery.user.entity;
+
+public enum SortType {
+    ID, USERNAME, NICKNAME, EMAIL
+}

--- a/src/main/java/com/bestcat/delivery/user/repository/UserCustomRepository.java
+++ b/src/main/java/com/bestcat/delivery/user/repository/UserCustomRepository.java
@@ -1,0 +1,11 @@
+package com.bestcat.delivery.user.repository;
+
+import com.bestcat.delivery.user.entity.SortType;
+import com.bestcat.delivery.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserCustomRepository{
+    Page<User> findAll(String search, SortType searchType, String roleType, Pageable pageable, SortType sort, boolean isAsc);
+
+}

--- a/src/main/java/com/bestcat/delivery/user/repository/UserRepository.java
+++ b/src/main/java/com/bestcat/delivery/user/repository/UserRepository.java
@@ -1,11 +1,15 @@
 package com.bestcat.delivery.user.repository;
 
 import com.bestcat.delivery.user.entity.User;
+import java.nio.channels.FileChannel;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, UUID>, UserCustomRepository {
     boolean existsByEmailAndDeletedAtIsNull(String email);
 
     boolean existsByUsernameAndDeletedAtIsNull(String username);
@@ -14,7 +18,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 
-    Optional<User> findByUsername(String username);
-
     Optional<User> findByIdAndDeletedAtIsNull(UUID id);
+
+
 }

--- a/src/main/java/com/bestcat/delivery/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/bestcat/delivery/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,111 @@
+package com.bestcat.delivery.user.repository;
+
+import static com.bestcat.delivery.user.entity.SortType.ID;
+import static com.bestcat.delivery.user.entity.SortType.NICKNAME;
+import static com.bestcat.delivery.user.entity.SortType.USERNAME;
+
+import com.bestcat.delivery.user.entity.QUser;
+import com.bestcat.delivery.user.entity.RoleType;
+import com.bestcat.delivery.user.entity.SortType;
+import com.bestcat.delivery.user.entity.User;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserRepositoryImpl implements UserCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public UserRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<User> findAll(String search, SortType searchType, String roleType, Pageable pageable, SortType sort, boolean isAsc) {
+        QUser user = QUser.user;
+
+        // 조건 설정
+        BooleanExpression condition = search(search, searchType, user);
+
+        // QueryDSL 쿼리
+        List<User> results = queryFactory
+                .selectFrom(user)
+                .where(condition, searchRoleType(roleType))
+                .orderBy(orderSpecifier(sort, isAsc))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 카운트
+        JPAQuery<Long> total = queryFactory
+                .select(user.count())
+                .from(user)
+                .where(condition);
+
+        return new PageImpl<>(results, pageable, total.fetchOne() == null ? 0 : total.fetchOne());
+    }
+
+    private Predicate searchRoleType(String roleType) {
+        if(roleType == null || roleType.isEmpty()) {
+            return QUser.user.role.in(RoleType.CUSTOMER, RoleType.OWNER);
+        }
+
+        if(roleType.equals(RoleType.CUSTOMER.toString())) {
+            return QUser.user.role.in(RoleType.CUSTOMER);
+        }
+
+        if (roleType.equalsIgnoreCase(RoleType.OWNER.toString())) {
+            return QUser.user.role.in(RoleType.OWNER);
+        }
+
+        return null;
+    }
+
+    private OrderSpecifier<?> orderSpecifier(SortType sortType, boolean isAsc) {
+        if(sortType == ID) {
+            return isAsc ? QUser.user.id.asc() : QUser.user.id.desc();
+        }
+
+        if(sortType == USERNAME) {
+            return isAsc ? QUser.user.username.asc() : QUser.user.username.desc();
+        }
+
+        if(sortType == NICKNAME) {
+            return isAsc ? QUser.user.nickname.asc() : QUser.user.nickname.desc();
+        }
+
+        return isAsc ? QUser.user.email.asc() : QUser.user.email.desc();
+
+    }
+
+    private BooleanExpression search(String search, SortType searchType, QUser user) {
+        if(search == null || search.isEmpty()) {
+            return null;
+        }
+
+        if(searchType == ID) {
+            return user.id.eq(UUID.fromString(search));
+        }
+
+        if(searchType == USERNAME) {
+            return user.username.containsIgnoreCase(search);
+        }
+
+        if(searchType == NICKNAME) {
+            return user.nickname.containsIgnoreCase(search);
+        }
+
+        return user.email.containsIgnoreCase(search);
+    }
+
+}

--- a/src/main/java/com/bestcat/delivery/user/service/AdminService.java
+++ b/src/main/java/com/bestcat/delivery/user/service/AdminService.java
@@ -1,0 +1,27 @@
+package com.bestcat.delivery.user.service;
+
+import com.bestcat.delivery.user.dto.UserDetailsInfoDto;
+import com.bestcat.delivery.user.entity.SortType;
+import com.bestcat.delivery.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+
+
+    public Page<UserDetailsInfoDto> getUserInfo(String query, SortType searchType, String roleType, Integer page, Integer size, SortType sort,
+                                                boolean isAsc) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        return userRepository.findAll(query, searchType, roleType, pageable, sort, isAsc)
+                .map(UserDetailsInfoDto::new);
+    }
+
+}

--- a/src/main/java/com/bestcat/delivery/user/service/UserService.java
+++ b/src/main/java/com/bestcat/delivery/user/service/UserService.java
@@ -13,10 +13,6 @@ import com.bestcat.delivery.user.dto.DeliveryAddressResponseDto;
 import static com.bestcat.delivery.common.type.ErrorCode.ALREADY_EXIST_NICKNAME;
 import static com.bestcat.delivery.common.type.ErrorCode.NEW_PASSWORD_SAME_AS_CURRENT;
 import static com.bestcat.delivery.common.type.ErrorCode.PASSWORD_MISMATCH;
-import static com.bestcat.delivery.common.type.ErrorCode.USER_ID_MISMATCH;
-import static com.bestcat.delivery.common.type.ErrorCode.USER_NOT_FOUND;
-
-import com.bestcat.delivery.common.exception.RestApiException;
 import com.bestcat.delivery.user.dto.NicknameRequestDto;
 import com.bestcat.delivery.user.dto.PasswordRequestDto;
 import com.bestcat.delivery.user.dto.SignupRequestDto;
@@ -29,7 +25,6 @@ import com.bestcat.delivery.user.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import java.util.UUID;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/com/bestcat/delivery/user/web/AdminController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/AdminController.java
@@ -1,0 +1,40 @@
+package com.bestcat.delivery.user.web;
+
+import static com.bestcat.delivery.common.type.ResponseMessage.GET_USER_INFO_SUCCESS;
+
+import com.bestcat.delivery.common.dto.SuccessResponse;
+import com.bestcat.delivery.common.util.UserDetailsImpl;
+import com.bestcat.delivery.user.dto.UserDetailsInfoDto;
+import com.bestcat.delivery.user.dto.UserInfoDto;
+import com.bestcat.delivery.user.entity.SortType;
+import com.bestcat.delivery.user.service.AdminService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admins")
+public class AdminController {
+    private final AdminService adminService;
+
+    @GetMapping("/search-users")
+    @Secured({"ROLE_MASTER", "ROLE_MANAGER"})
+    public ResponseEntity<SuccessResponse<Page<UserDetailsInfoDto>>> getUserInfo(
+              @RequestParam(required = false, name = "search") String search,
+              @RequestParam(required = false, defaultValue = "USERNAME", name = "type") SortType searchType,
+              @RequestParam(required = false, name = "role") String roleType,
+              @RequestParam(defaultValue = "0", name = "page") Integer page,
+              @RequestParam(defaultValue = "10", name = "size") Integer size,
+              @RequestParam(defaultValue = "ID", name = "sort") SortType sort,
+              @RequestParam(defaultValue = "true", name = "isAsc") boolean isAsc) {
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(GET_USER_INFO_SUCCESS, adminService.getUserInfo(search, searchType, roleType, page, size, sort, isAsc)));
+    }
+}

--- a/src/main/java/com/bestcat/delivery/user/web/UserController.java
+++ b/src/main/java/com/bestcat/delivery/user/web/UserController.java
@@ -22,14 +22,11 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -62,6 +59,8 @@ public class UserController {
         return ResponseEntity.ok(SuccessResponse.of(DELETE_USER_SUCCESS));
     }
 
+    @GetMapping
+    @Secured({"ROLE_MASTER", "ROLE_MANAGER", "ROLE_OWNER", "ROLE_CUSTOMER"})
     public ResponseEntity<SuccessResponse<UserInfoDto>> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok().body(
                 SuccessResponse.of(GET_USER_INFO_SUCCESS, userService.getUserInfo(userDetails.getUser())));
@@ -93,7 +92,6 @@ public class UserController {
                 NICKNAME_UPDATE_SUCCESS, userService.updateNickname(userId, userDetails.getUser(), nickname)
         ));
     }
-
 
     @PostMapping("/{userId}/delivery")
     @Secured({"ROLE_CUSTOMER"})


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 

## 📝작업 내용

> queryDSL 사용을 위한 설정 파일 추가

> queryDSL 로 findAll 메서드 구성
- search : 쿼리문
- type : 검색어 타입 ( id, username(기본값), nickname, email)
- sort : 정렬 타입 ( id(기본값), username, nickname, email)
- isAsc 
  - true : 오름차순
  - false : 내림차순
- page : 페이지 번호 (default : 0)
- size : 한 페이지의 수 (default : 10)
- role : 검색할 role 타입 (null 인 경우 두 타입 모두, CUSTOMER, OWNER)
![image](https://github.com/user-attachments/assets/052ef8a5-1d51-458e-ae4a-b56969ba2c60)

![image](https://github.com/user-attachments/assets/6224ff45-e76e-4e62-8232-64caf41e3f35)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 처음 queryDSL 을 사용해보아서 제대로 코드를 작성한건지 한번 봐주시면 감사하겠습니다!
